### PR TITLE
Prevents new versions of charts packages from breaking Results

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "chart.js": "^2.6.0",
+    "chart.js": ">=2.6.x < 2.7.x",
     "gh-pages": "^1.0.0",
     "lodash": "^4.17.4",
     "react": "^15.6.1",
-    "react-chartjs-2": "^2.5.7",
+    "react-chartjs-2": "<=2.6.1 >2.6.0",
     "react-dom": "^15.6.1",
     "react-redirect": "^1.0.0",
     "react-router": "^4.1.2",

--- a/src/helpers/Result.js
+++ b/src/helpers/Result.js
@@ -50,7 +50,7 @@ class Result {
 
 
 // ========================================
-// =========================================
+// ========================================
 // VALIDATION
 // ========================================
 // ========================================
@@ -60,7 +60,7 @@ class Result {
 */
 var checkTypes = function ( data ) {
 
-  /** @todo Is there a way to lop through to do this? I attempted
+  /** @todo Is there a way to loop through to do this? I attempted
   * it with a 'types' object to check types, but type tests aren't
   * enough. For example, `expirationDate` needs to be tested for
   * `instanceof Date`. */


### PR DESCRIPTION
Otherwise top line of chart gets cut off.

Sorry about the typo fix accidentally included.