### PR TITLE
Addresses second point of issue #40

### DIFF
--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -234,7 +234,8 @@ const Results = (props) => {
                * we are using chart.js v2.7 so it requires a callback function
                */
               callback: function(label) {
-                  return label.toLocaleString("en-US",{style:"currency", currency:"USD"}).replace('.00','');
+                  return label.toLocaleString("en-US",{style:"currency", 
+                      currency:"USD"}).replace('.00','');
               }
           }
         }],
@@ -245,16 +246,34 @@ const Results = (props) => {
           },
             ticks: {
               callback: function(label) {
-                  return label.toLocaleString("en-US",{style:"currency", currency:"USD"}).replace('.00','');
+                  return label.toLocaleString("en-US",{style:"currency", 
+                      currency:"USD"}).replace('.00','');
               }
             }
         }]
     },
+      /* to add number formatting to the tooltips. returns the data label + currency format 
+       * from https://github.com/chartjs/Chart.js/issues/2386
+       *
+       * default tooltip for chart.js 2.0+  when unspecified looks like:
+       *
+       * options: {
+       *   tooltips: {
+       *       callbacks: {
+       *           label: function(tooltipItem, data) {
+       *               return tooltipItem.yLabel;
+       *           }
+       *       }
+       *   }
+       * }
+       *
+       */
     tooltips: {
         callbacks: {
             label: function(tooltipItem, data) {
-                return tooltipItem.yLabel.toLocaleString("en-US",{style:"currency", currency:"USD"})
-                    .replace('.00','');
+                return data.datasets[tooltipItem.datasetIndex].label + " " + 
+                    tooltipItem.yLabel.toLocaleString("en-US",{style:"currency", 
+                        currency:"USD"}).replace('.00','');
             }
         }
     }

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -234,8 +234,7 @@ const Results = (props) => {
                * we are using chart.js v2.7 so it requires a callback function
                */
               callback: function(label) {
-                  return label.toLocaleString("en-US",{style:"currency", 
-                      currency:"USD"}).replace('.00','');
+                  return label.toLocaleString("en-US");
               }
           }
         }],
@@ -246,15 +245,12 @@ const Results = (props) => {
           },
             ticks: {
               callback: function(label) {
-                  return label.toLocaleString("en-US",{style:"currency", 
-                      currency:"USD"}).replace('.00','');
+                  return label.toLocaleString("en-US");
               }
             }
         }]
     },
-      /* to add number formatting to the tooltips. returns the data label + currency format 
-       * from https://github.com/chartjs/Chart.js/issues/2386
-       *
+      /*        
        * default tooltip for chart.js 2.0+  when unspecified looks like:
        *
        * options: {
@@ -270,6 +266,16 @@ const Results = (props) => {
        */
     tooltips: {
         callbacks: {
+            // format the title of the tooltips to be in USD
+            title: function(tooltipItems, data) {
+                return data.labels[tooltipItems[0].index].toLocaleString("en-US",
+                    {style:"currency",currency:"USD"}).replace('.00','');
+            },
+            /*
+             * to add number formatting to the tooltips. returns the data label 
+             * + currency format 
+             * from https://github.com/chartjs/Chart.js/issues/2386
+             */
             label: function(tooltipItem, data) {
                 return data.datasets[tooltipItem.datasetIndex].label + ": " + 
                     tooltipItem.yLabel.toLocaleString("en-US",{style:"currency", 

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -271,7 +271,7 @@ const Results = (props) => {
     tooltips: {
         callbacks: {
             label: function(tooltipItem, data) {
-                return data.datasets[tooltipItem.datasetIndex].label + " " + 
+                return data.datasets[tooltipItem.datasetIndex].label + ": " + 
                     tooltipItem.yLabel.toLocaleString("en-US",{style:"currency", 
                         currency:"USD"}).replace('.00','');
             }

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -212,13 +212,13 @@ const Results = (props) => {
       data: housingData, //xRange.map(x => getHousingEligibility({ annualIncome: x, householdSize: props.pageState.householdSize }).benefitValue),
       fill: false
     },
-    ]
-  };
+    ]};
 
   var options = {
     title: {
       display: true,
-      text: 'Benefit Eligibility for Household Size ' + props.pageState.householdSize
+        text: 'Benefit Eligibility for Household Size ' + 
+                props.pageState.householdSize
     },
     showLines: true,
     scales: {
@@ -249,8 +249,16 @@ const Results = (props) => {
               }
             }
         }]
+    },
+    tooltips: {
+        callbacks: {
+            label: function(tooltipItem, data) {
+                return tooltipItem.yLabel.toLocaleString("en-US",{style:"currency", currency:"USD"})
+                    .replace('.00','');
+            }
+        }
     }
-  }
+  };
 
   // return (
   //   <wrapper className = 'result-page'>

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -183,7 +183,7 @@ const Results = (props) => {
   var massHealthData = xRange.map(x => {
       client.annualIncome = x;
       return getMassHealthEligibility(client).benefitValue});
-  
+    
   var snapData = xRange.map(x => {
       client.annualIncome = x;
       return getSnapEligibility(client).benefitValue});
@@ -225,20 +225,32 @@ const Results = (props) => {
         yAxes: [{
           scaleLabel: {
             display: true,
-            labelString: 'Benefit Value ($)'
+              labelString: 'Benefit Value ($)'
           },
           ticks: {
-              beginAtZero: true
+              beginAtZero: true,
+              /*
+               * function to add $ and 1,000s separators to graph axes
+               * we are using chart.js v2.7 so it requires a callback function
+               */
+              callback: function(label) {
+                  return label.toLocaleString("en-US",{style:"currency", currency:"USD"}).replace('.00','');
+              }
           }
         }],
         xAxes: [{
           scaleLabel: {
             display: true,
-            labelString: 'Annual Income ($)'
-          }
+              labelString: 'Annual Income ($)'
+          },
+            ticks: {
+              callback: function(label) {
+                  return label.toLocaleString("en-US",{style:"currency", currency:"USD"}).replace('.00','');
+              }
+            }
         }]
     }
-  };
+  }
 
   // return (
   //   <wrapper className = 'result-page'>


### PR DESCRIPTION
Added thousands separators to the axes on the results chart. I also formatted the tooltips to  show values in $ with the thousands separators. Comments explain tooltip formatting for chart.js 2.0