### PR TITLE
Fixes value setting callbacks and 'current' values not being set

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -182,6 +182,7 @@ const MassiveToggle = function ( props ) {
       checked={ props.checked || props.value }
       onChange={ props.onChange || props.storeChecked }
       name={ props.name || props.id }
+      id={ props.name || props.id }
       control={ Checkbox }
       size='massive'/>
   );

--- a/src/forms/household-size.js
+++ b/src/forms/household-size.js
@@ -28,10 +28,40 @@ const HouseholdSizeContent = (props) => {
       client = origin.pageState,
       time   = 'previous';
 
+
+  /** Makes sure values are propagated to 'current' properties if needed */
+  var ensureCurrComplex = function ( evnt, inputProps ) {
+
+    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    if ( !client[ keyOfCurr ] ) {
+      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+    }
+
+    // Do the usual thing too
+    origin.storeComplex( evnt, inputProps );
+
+  };  // End ensureCurrComplex()
+
+
+  /** Makes sure values are propagated to 'current' properties if needed */
+  var ensureCurrChecked = function ( evnt, inputProps ) {
+    
+    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    if ( !client[ keyOfCurr ] ) {
+      origin.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+    }
+
+    // Do the usual thing too
+    origin.storeChecked( evnt, inputProps );
+
+  };  // End ensureCurrChecked()
+
+
   var numberChange = function ( evnt, inputProps ) {
-    var val = limit( inputProps.value, { min: 0, max: inputProps.max } );
-    origin.storeComplex( evnt, {name: inputProps.id, value: val} );
+    var val = limit( inputProps.value, { min: inputProps.min, max: inputProps.max } );
+    ensureCurrComplex( evnt, {name: inputProps.id, id: inputProps.id, value: val} );
   };
+
 
   return (      
     <wrapper className={'field-aligner'}>
@@ -55,7 +85,7 @@ const HouseholdSizeContent = (props) => {
           value     = {client[ time + 'HouseholdSize' ] || 1}
           name      = {time + 'HouseholdSize'}
           id        = {time + 'HouseholdSize'}
-          type={'number'} step={1} min={0} max={8} />
+          type={'number'} step={1} min={1} max={8} />
         <wrapper>
           <label>Number of members in the household</label>
           <InlineLabelInfo>Including live-in aides.</InlineLabelInfo>
@@ -66,7 +96,7 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'Dependents'}
           onChange  = {numberChange}
-          value     = {client[ time + 'Dependents' ] || 0}
+          value     = {client[ time + 'Dependents' ] || ''}
           name      = {time + 'Dependents'}
           id        = {time + 'Dependents'}
           type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
@@ -80,7 +110,7 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'ChildrenUnder12'}
           onChange  = {numberChange}
-          value     = {client[ time + 'ChildrenUnder12' ] || 0}
+          value     = {client[ time + 'ChildrenUnder12' ] || ''}
           name      = {time + 'ChildrenUnder12'}
           id        = {time + 'ChildrenUnder12'}
           type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
@@ -90,12 +120,12 @@ const HouseholdSizeContent = (props) => {
       </Form.Field>
 
       <MassiveToggle id={time + 'DisabledOrElderlyHeadOrSpouse'} value={client[ time + 'DisabledOrElderlyHeadOrSpouse' ]}
-        storeChecked={origin.storeChecked}
+        storeChecked={ensureCurrChecked}
         label={'Was the head of household or their spouse considered disabled, handicapped, or elderly (62 or older)?'} />
 
       {/** Really should be split into disabled under 12 and other disabled? */}
       <MassiveToggle id={time + 'DisabledOrElderlyMember'} value={client[ time + 'DisabledOrElderlyMember' ]}
-        storeChecked={origin.storeChecked}
+        storeChecked={ensureCurrChecked}
         label={'Was any other household member, including children, considered disabled, handicapped, or elderly (62 or older)?'} />
 
     </wrapper>

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -27,13 +27,9 @@ import { roundMoney, limit } from '../helpers/math';
 */
 const Housing = function ( props ) {
 
-  var client        = props.props.pageState,
-      time          = props.time,
-      storeChecked  = props.props.storeChecked,
-      sharedProps   = {
-        client: client, type: props.type, time: time,
-        storeComplex: props.props.storeComplex
-      };
+  var origin        = props.props,
+      client        = origin.pageState,
+      time          = props.time;
 
   // `hasHousing` is actually whether they're in the housing voucher program
   var ownedAHome  = client[ time + 'Homeowner' ],
@@ -42,6 +38,42 @@ const Housing = function ( props ) {
 
   var utils = client[ time + 'PaidUtilities' ], climate = client[ time + 'GotClimateControl' ],
       electricity = client[ time + 'NonHeatElectricity' ], phone = client[ time + 'Phone' ];
+
+
+  /** Makes sure values are propagated to 'current' properties if needed */
+  var ensureCurrComplex = function ( evnt, inputProps ) {
+    
+    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    if ( !client[ keyOfCurr ] ) {
+      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+    }
+
+    // Do the usual thing too
+    origin.storeComplex( evnt, inputProps );
+
+  };  // End ensureCurrComplex()
+
+
+  /** Makes sure values are propagated to 'current' properties if needed */
+  var ensureCurrChecked = function ( evnt, inputProps ) {
+    
+    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    if ( !client[ keyOfCurr ] ) {
+      origin.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+    }
+
+    // Do the usual thing too
+    origin.storeChecked( evnt, inputProps );
+
+  };  // End ensureCurrChecked()
+
+
+  var storeChecked  = ensureCurrChecked,
+      sharedProps   = {
+        client: client, type: props.type, time: time,
+        storeComplex: ensureCurrComplex
+      };
+
 
   /** @todo Owning a home vs. rented vs. homeless should probably be radio buttons */
   return (

--- a/src/forms/previousIncome.js
+++ b/src/forms/previousIncome.js
@@ -48,12 +48,28 @@ import { merge } from '../helpers/object-manipulation';
 */
 const IncomeForm = function ( props ) {
 
-  var time = 'previous', type = 'income';
+  var time    = 'previous',
+      type    = 'income',
+      client  = props.client,
+      origin  = props.props;
 
-  var client      = props.client,
-      otherProps  = props.props,
-      sharedProps = { client: client, type: type, time: time,
-                    storeComplex: otherProps.storeComplex };
+
+  /** Makes sure values are propagated to 'current' properties if needed */
+  var ensureCurrent = function ( evnt, inputProps ) {
+    
+    var keyOfCurr = inputProps.name.replace( 'previous', 'current' );
+    if ( !client[ keyOfCurr ] ) {
+      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+    }
+
+    // Do the usual thing too
+    origin.storeComplex( evnt, inputProps );
+
+  };  // End ensureCurrent()
+
+
+  var sharedProps = { client: client, type: type, time: time,
+                      storeComplex: ensureCurrent };
 
   return (
     <div className='field-aligner two-column'>

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -403,19 +403,21 @@ class VisitPage extends Component {
   }
 
   storeChecked = (e, { name, checked }, callback) => {
-    this.setState({ [name]: checked },
+    var truth = this;
+    truth.setState({ [name]: checked },
       function () {
-       // console.log(name, checked, this);
-       if ( callback ) { callback( this ); }
+       // console.log( name, checked, truth );
+       if ( callback ) { callback( truth ); }
     });
   }
 
   storeComplex = (e, { name, value }, callback) => {
-    this.setState(
+    var truth = this;
+    truth.setState(
       { [name]: value },
       function () {
-        // console.log(this);
-        if ( callback ) { callback( this ); }
+        // console.log( truth );
+        if ( callback ) { callback( truth ); }
       }  // This is given no arguments
     );
   }


### PR DESCRIPTION
1. State value setting functions were passing `undefined` to their callbacks. They should now be sending the 'source of truth' for the page.
2. Ensures 'current' values will be prefilled with 'previous' (if possible) so calcs that use both will have consistent values.

Sorry for the multi-purpose pull. If needed I can split it into two.