### PR TITLE
Created a test suite for the roundMoney function in math.js

### DIFF
--- a/src/helpers/math.test.js
+++ b/src/helpers/math.test.js
@@ -1,0 +1,33 @@
+const math = require('./math');
+
+test('Rounding up', () => {
+    expect(math.roundMoney(1.005)).toBe(1.01);
+});
+
+test('Rounding down', () => {
+    expect(math.roundMoney(1.0049)).toBe(1.0);
+});
+
+// While 0 and -0 work the same in most cases, we want to avoid displaying -0 since the concept of -0 can be confusing for some people
+test('Rounding to -0', () => {
+    var roundedNegZero = math.roundMoney(-0);
+    expect(Object.is(roundedNegZero, 0)).toBe(true);
+});
+
+// This is a more of a pedantic than practical case since values representing money should not reach anywhere close to Number.MAX_VALUE
+// However, rounding Number.MAX_VALUE to two decimal places should not cause it to become infinity
+/*
+test('Rounding a very large number', () => {
+    expect(math.roundMoney(Number.MAX_VALUE)).toBeCloseTo(Number.MAX_VALUE);
+});
+*/
+
+test('Rounding infinity', () => {
+    expect(math.roundMoney(Infinity)).toBe(Infinity);
+});
+
+test('Rounding NaN', () => {
+    var roundedNan = math.roundMoney(NaN);
+    expect(isNaN(roundedNan)).toBe(true);
+});
+


### PR DESCRIPTION
Right now roundMoney fails to pass 2 tests that I think are important. The most important is that it fails to  round 1.005 to 1.01, which is a result of representing money using binary floating point. We might want to switch to a decimal number library after the mvp so results are more consistent with what people expect. I also feel that roundMoney should convert -0 to 0 to reduce the possibility of displaying -0 somewhere on the website since the concept of -0 can be confusing.