### PR TITLE
Get rid of nested objects in props

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We use GitHub Issues to organize our work.  Here's some quick reading about [how
 
 Aren't familiar with Git?  Spend ~15 minutes learning with this [interactive Git tutorial](https://try.github.io/levels/1/challenges/1).
 
-[Create React App README](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
+The app was bootstrapped with the Create React App CLI. You can view the [README here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
 
 
 ## Environment Setup
@@ -40,6 +40,6 @@ Aren't familiar with Git?  Spend ~15 minutes learning with this [interactive Git
 6. Install all necessary node packages with `npm install`. This might take a few minutes.
 7. Type `npm start` to automatically open a browser window and run the app in your browser in dev mode. If you make changes to a file and save it, the page will automatically update and use the new code. Would also recommend getting the [React Developer Tools](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=4&cad=rja&uact=8&ved=0ahUKEwiZ__6Vg_jVAhWQ14MKHczrDtoQFgg4MAM&url=https%3A%2F%2Fchrome.google.com%2Fwebstore%2Fdetail%2Freact-developer-tools%2Ffmkadmapgofadopljbjfkapdkoienihi%3Fhl%3Den&usg=AFQjCNEv0udXgBoaukzJa59I_vufhScUbQ) extension for Chrome.
 8. `Ctrl-C` to stop the app when it's running.
-9. Type `npm run deploy` to build a production version of the app.
+9. Type `npm run build` to build a production version of the app.
 
 We currently have it set up to deploy automatically to GitHub pages with `npm run deploy`.

--- a/src/forms/citizenship.js
+++ b/src/forms/citizenship.js
@@ -18,8 +18,7 @@ import {
 */
 const CitizenshipContent = (props) => {
 
-	var origin = props.origin,
-      client = origin.pageState;
+	var client = props.pageState;
 
   return (
     <wrapper className={'field-aligner'}>
@@ -29,7 +28,7 @@ const CitizenshipContent = (props) => {
           name='citizenshipStatus'
           value='citizen'
           checked={client.citizenshipStatus === 'citizen'}
-          onChange={origin.storeComplex}
+          onChange={props.storeComplex}
         />
       </Form.Field>
       <br/>
@@ -39,7 +38,7 @@ const CitizenshipContent = (props) => {
           name='citizenshipStatus'
           value='immigrant'
           checked={client.citizenshipStatus === 'immigrant'}
-          onChange={origin.storeComplex}
+          onChange={props.storeComplex}
         />
       </Form.Field>
       <br/>
@@ -49,7 +48,7 @@ const CitizenshipContent = (props) => {
           name='citizenshipStatus'
           value='unknown'
           checked={client.citizenshipStatus === 'unknown'}
-          onChange={origin.storeComplex}
+          onChange={props.storeComplex}
         />
       </Form.Field>
     </wrapper>
@@ -75,7 +74,7 @@ const CitizenshipStep = function ( props ) {
         clarifier = {'Select your citizenship status.'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <CitizenshipContent origin={props}/>
+          <CitizenshipContent {...props} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/citizenship.js
+++ b/src/forms/citizenship.js
@@ -1,5 +1,5 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Radio } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS

--- a/src/forms/citizenship.js
+++ b/src/forms/citizenship.js
@@ -18,8 +18,6 @@ import {
 */
 const CitizenshipContent = (props) => {
 
-	var client = props.pageState;
-
   return (
     <wrapper className={'field-aligner'}>
       <Form.Field>
@@ -27,7 +25,7 @@ const CitizenshipContent = (props) => {
           label='US Citizen / National'
           name='citizenshipStatus'
           value='citizen'
-          checked={client.citizenshipStatus === 'citizen'}
+          checked={props.client.citizenshipStatus === 'citizen'}
           onChange={props.storeComplex}
         />
       </Form.Field>
@@ -37,7 +35,7 @@ const CitizenshipContent = (props) => {
           label='Lawfully present immigrant / AWSS'
           name='citizenshipStatus'
           value='immigrant'
-          checked={client.citizenshipStatus === 'immigrant'}
+          checked={props.client.citizenshipStatus === 'immigrant'}
           onChange={props.storeComplex}
         />
       </Form.Field>
@@ -47,7 +45,7 @@ const CitizenshipContent = (props) => {
           label="Don't Know"
           name='citizenshipStatus'
           value='unknown'
-          checked={client.citizenshipStatus === 'unknown'}
+          checked={props.client.citizenshipStatus === 'unknown'}
           onChange={props.storeComplex}
         />
       </Form.Field>
@@ -74,7 +72,7 @@ const CitizenshipStep = function ( props ) {
         clarifier = {'Select your citizenship status.'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <CitizenshipContent {...props} />
+          <CitizenshipContent storeComplex={props.storeComplex} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/citizenship.js
+++ b/src/forms/citizenship.js
@@ -16,7 +16,7 @@ import {
 * 
 * @returns Component
 */
-const CitizenshipContent = (props) => {
+const CitizenshipContent = ({ storeComplex, client }) => {
 
   return (
     <wrapper className={'field-aligner'}>
@@ -25,8 +25,8 @@ const CitizenshipContent = (props) => {
           label='US Citizen / National'
           name='citizenshipStatus'
           value='citizen'
-          checked={props.client.citizenshipStatus === 'citizen'}
-          onChange={props.storeComplex}
+          checked={client.citizenshipStatus === 'citizen'}
+          onChange={storeComplex}
         />
       </Form.Field>
       <br/>
@@ -35,8 +35,8 @@ const CitizenshipContent = (props) => {
           label='Lawfully present immigrant / AWSS'
           name='citizenshipStatus'
           value='immigrant'
-          checked={props.client.citizenshipStatus === 'immigrant'}
-          onChange={props.storeComplex}
+          checked={client.citizenshipStatus === 'immigrant'}
+          onChange={storeComplex}
         />
       </Form.Field>
       <br/>
@@ -45,8 +45,8 @@ const CitizenshipContent = (props) => {
           label="Don't Know"
           name='citizenshipStatus'
           value='unknown'
-          checked={props.client.citizenshipStatus === 'unknown'}
-          onChange={props.storeComplex}
+          checked={client.citizenshipStatus === 'unknown'}
+          onChange={storeComplex}
         />
       </Form.Field>
     </wrapper>

--- a/src/forms/current-benefits.js
+++ b/src/forms/current-benefits.js
@@ -18,28 +18,26 @@ import {
 * 
 * @returns Component
 */
-const CurrentBenefitsContent = (props) => {
-
-  var client = props.pageState;
+const CurrentBenefitsContent = ({ client, storeChecked }) => {
 
   return (
     <wrapper className={'field-aligner'}>
       <MassiveToggle
-        label={{ children: props.client.hasSnap ? <strong>SNAP</strong> : 'SNAP' }}
-        checked={props.client.hasSnap}
-        onChange={props.storeChecked}
+        label={{ children: client.hasSnap ? <strong>SNAP</strong> : 'SNAP' }}
+        checked={client.hasSnap}
+        onChange={storeChecked}
         name='hasSnap' />
       <br/>
       <MassiveToggle
-        label={{ children: props.client.hasHousing ? <strong>Section 8 Housing</strong> : 'Section 8 Housing' }}
-        checked={props.client.hasHousing}
-        onChange={props.storeChecked}
+        label={{ children: client.hasHousing ? <strong>Section 8 Housing</strong> : 'Section 8 Housing' }}
+        checked={client.hasHousing}
+        onChange={storeChecked}
         name='hasHousing' />
       <br/>
       <MassiveToggle
-        label={{ children: props.client.hasMassHealth ? <strong>MassHealth</strong> : 'MassHealth' }}
-        checked={props.client.hasMassHealth}
-        onChange={props.storeChecked}
+        label={{ children: client.hasMassHealth ? <strong>MassHealth</strong> : 'MassHealth' }}
+        checked={client.hasMassHealth}
+        onChange={storeChecked}
         name='hasMassHealth' />
     </wrapper>
   );  // end return

--- a/src/forms/current-benefits.js
+++ b/src/forms/current-benefits.js
@@ -20,27 +20,26 @@ import {
 */
 const CurrentBenefitsContent = (props) => {
 
-	var origin = props.origin,
-      client = origin.pageState;
+  var client = props.pageState;
 
   return (
     <wrapper className={'field-aligner'}>
       <MassiveToggle
         label={{ children: client.hasSnap ? <strong>SNAP</strong> : 'SNAP' }}
         checked={client.hasSnap}
-        onChange={origin.storeChecked}
+        onChange={props.storeChecked}
         name='hasSnap' />
       <br/>
       <MassiveToggle
         label={{ children: client.hasHousing ? <strong>Section 8 Housing</strong> : 'Section 8 Housing' }}
         checked={client.hasHousing}
-        onChange={origin.storeChecked}
+        onChange={props.storeChecked}
         name='hasHousing' />
       <br/>
       <MassiveToggle
         label={{ children: client.hasMassHealth ? <strong>MassHealth</strong> : 'MassHealth' }}
         checked={client.hasMassHealth}
-        onChange={origin.storeChecked}
+        onChange={props.storeChecked}
         name='hasMassHealth' />
     </wrapper>
   );  // end return
@@ -64,7 +63,7 @@ const CurrentBenefitsStep = (props) => {
         title     = {'Current Benefits'}
         clarifier = {'Select the benefits you currently receive.'}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <CurrentBenefitsContent origin={props}/>
+          <CurrentBenefitsContent {...props} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/current-benefits.js
+++ b/src/forms/current-benefits.js
@@ -25,20 +25,20 @@ const CurrentBenefitsContent = (props) => {
   return (
     <wrapper className={'field-aligner'}>
       <MassiveToggle
-        label={{ children: client.hasSnap ? <strong>SNAP</strong> : 'SNAP' }}
-        checked={client.hasSnap}
+        label={{ children: props.client.hasSnap ? <strong>SNAP</strong> : 'SNAP' }}
+        checked={props.client.hasSnap}
         onChange={props.storeChecked}
         name='hasSnap' />
       <br/>
       <MassiveToggle
-        label={{ children: client.hasHousing ? <strong>Section 8 Housing</strong> : 'Section 8 Housing' }}
-        checked={client.hasHousing}
+        label={{ children: props.client.hasHousing ? <strong>Section 8 Housing</strong> : 'Section 8 Housing' }}
+        checked={props.client.hasHousing}
         onChange={props.storeChecked}
         name='hasHousing' />
       <br/>
       <MassiveToggle
-        label={{ children: client.hasMassHealth ? <strong>MassHealth</strong> : 'MassHealth' }}
-        checked={client.hasMassHealth}
+        label={{ children: props.client.hasMassHealth ? <strong>MassHealth</strong> : 'MassHealth' }}
+        checked={props.client.hasMassHealth}
         onChange={props.storeChecked}
         name='hasMassHealth' />
     </wrapper>
@@ -63,7 +63,7 @@ const CurrentBenefitsStep = (props) => {
         title     = {'Current Benefits'}
         clarifier = {'Select the benefits you currently receive.'}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <CurrentBenefitsContent {...props} />
+          <CurrentBenefitsContent storeChecked={props.storeChecked} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/current-benefits.js
+++ b/src/forms/current-benefits.js
@@ -1,6 +1,6 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
-import { Form, Radio } from 'semantic-ui-react';
+import React from 'react';
+import { Form } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
 import {

--- a/src/forms/currentIncome.js
+++ b/src/forms/currentIncome.js
@@ -30,9 +30,8 @@ const IncomeForm = function ( props ) {
   var time = 'current', type = 'income';
 
   var client      = props.client,
-      otherProps  = props.props,
       sharedProps = { client: client, type: type, time: time,
-                    storeComplex: otherProps.storeComplex };
+                    storeComplex: props.storeComplex };
 
   var monthly     = getSimpleGrossIncomeMonthly( client, 'current' ),
       grossAnnual = monthly * 12;
@@ -54,15 +53,15 @@ const IncomeForm = function ( props ) {
 
       <div style={{ textAlign: 'center' }}>
         <Header as='h4' textAlign='center'>
-          FOR A HOUSEHOLD SIZE OF <strong>{ otherProps.pageState.householdSize }</strong>:
+          FOR A HOUSEHOLD SIZE OF <strong>{ props.pageState.householdSize }</strong>:
         </Header>
         <Statistic>
           <Statistic.Label>Federal Poverty Level Percentage</Statistic.Label>
-          <Statistic.Value>{Math.round( percentPovertyLevel( grossAnnual, otherProps.pageState.householdSize ))}%</Statistic.Value>
+          <Statistic.Value>{Math.round( percentPovertyLevel( grossAnnual, props.pageState.householdSize ))}%</Statistic.Value>
         </Statistic>
         {/*<Statistic>
           <Statistic.Label>Area Median Income Percentage</Statistic.Label>
-          <Statistic.Value>{Math.round( percentStateMedianIncome( grossAnnual, otherProps.pageState.householdSize ))}%</Statistic.Value>
+          <Statistic.Value>{Math.round( percentStateMedianIncome( grossAnnual, props.pageState.householdSize ))}%</Statistic.Value>
         </Statistic>*/}
       </div>
 
@@ -91,7 +90,7 @@ const CurrentIncomeStep = function ( props ) {
         clarifier = 'How much money does your household make now?'
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <IncomeForm client={props.pageState} props={props}/>
+          <IncomeForm {...props} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/currentIncome.js
+++ b/src/forms/currentIncome.js
@@ -25,11 +25,10 @@ import { getSimpleGrossIncomeMonthly } from '../helpers/cashflow';
 * 
 * @returns Component
 */
-const IncomeForm = function ( props ) {
+const IncomeForm = function ({ storeComplex, client }) {
 
   var time = 'current', 
-	  type = 'income',
-	  client = props.client
+	  type = 'income'
 
   var monthly     = getSimpleGrossIncomeMonthly( client, 'current' ),
       grossAnnual = monthly * 12;
@@ -45,7 +44,7 @@ const IncomeForm = function ( props ) {
       <CashFlowRow client={client}
 				  type={type} 
 				  time={time}
-				  storeComplex={props.storeComplex}
+				  storeComplex={storeComplex}
 				  generic='EarnedIncome' 
 				  labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
           Earned income
@@ -56,15 +55,15 @@ const IncomeForm = function ( props ) {
 
       <div style={{ textAlign: 'center' }}>
         <Header as='h4' textAlign='center'>
-          FOR A HOUSEHOLD SIZE OF <strong>{ props.pageState.householdSize }</strong>:
+          FOR A HOUSEHOLD SIZE OF <strong>{ client.householdSize }</strong>:
         </Header>
         <Statistic>
           <Statistic.Label>Federal Poverty Level Percentage</Statistic.Label>
-          <Statistic.Value>{Math.round( percentPovertyLevel( grossAnnual, props.pageState.householdSize ))}%</Statistic.Value>
+          <Statistic.Value>{Math.round( percentPovertyLevel( grossAnnual, client.householdSize ))}%</Statistic.Value>
         </Statistic>
         {/*<Statistic>
           <Statistic.Label>Area Median Income Percentage</Statistic.Label>
-          <Statistic.Value>{Math.round( percentStateMedianIncome( grossAnnual, props.pageState.householdSize ))}%</Statistic.Value>
+          <Statistic.Value>{Math.round( percentStateMedianIncome( grossAnnual, client.householdSize ))}%</Statistic.Value>
         </Statistic>*/}
       </div>
 
@@ -93,7 +92,7 @@ const CurrentIncomeStep = function ( props ) {
         clarifier = 'How much money does your household make now?'
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <IncomeForm {...props} client={props.pageState} />
+          <IncomeForm prevStep={props.prevStep} nextStep={props.nextStep} storeComplex={props.storeComplex} storeChecked={props.storeChecked} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/currentIncome.js
+++ b/src/forms/currentIncome.js
@@ -27,11 +27,9 @@ import { getSimpleGrossIncomeMonthly } from '../helpers/cashflow';
 */
 const IncomeForm = function ( props ) {
 
-  var time = 'current', type = 'income';
-
-  var client      = props.client,
-      sharedProps = { client: client, type: type, time: time,
-                    storeComplex: props.storeComplex };
+  var time = 'current', 
+	  type = 'income',
+	  client = props.client
 
   var monthly     = getSimpleGrossIncomeMonthly( client, 'current' ),
       grossAnnual = monthly * 12;
@@ -44,7 +42,12 @@ const IncomeForm = function ( props ) {
     <div className='field-aligner two-column'>
 
       <IntervalColumnHeadings type={type}/>
-      <CashFlowRow {...sharedProps} generic={'EarnedIncome'} labelInfo={'(Weekly income = hourly wage times average number of work hours per week)'}>
+      <CashFlowRow client={client}
+				  type={type} 
+				  time={time}
+				  storeComplex={props.storeComplex}
+				  generic='EarnedIncome' 
+				  labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
           Earned income
       </CashFlowRow>
 

--- a/src/forms/currentIncome.js
+++ b/src/forms/currentIncome.js
@@ -1,13 +1,12 @@
 // COMPONENTS
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Header, Statistic } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
 import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formHelpers';
 
 // UTILITIES
-import { roundMoney, limit } from '../helpers/math';
-import { merge } from '../helpers/object-manipulation';
+import { roundMoney } from '../helpers/math';
 
 // BENEFIT PROGRAM CALCULATIONS
 import { percentPovertyLevel, percentStateMedianIncome } from '../helpers/helperFunctions';
@@ -46,8 +45,7 @@ const IncomeForm = function ( props ) {
     <div className='field-aligner two-column'>
 
       <IntervalColumnHeadings type={type}/>
-      <CashFlowRow {...merge( {generic: 'EarnedIncome',
-        labelInfo: '(Weekly income = hourly wage times average number of work hours per week)'}, sharedProps )}>
+      <CashFlowRow {...sharedProps} generic={'EarnedIncome'} labelInfo={'(Weekly income = hourly wage times average number of work hours per week)'}>
           Earned income
       </CashFlowRow>
 

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -14,7 +14,7 @@ import {
 } from 'semantic-ui-react';
 
 // UTILITIES
-import { roundMoney, limit, toMonthlyAmount } from '../helpers/math';
+import { roundMoney, toMonthlyAmount } from '../helpers/math';
 
 
 // ========================================
@@ -142,8 +142,6 @@ const FormPartsContainer = function(props) {
 * @returns Component
 */
 const MassiveToggle = function (props) {
-
-  var time = props.time || '';
 
   /** @todo Switch props.storeChecked to props.onChange everywhere */
   return (
@@ -400,12 +398,7 @@ const CashFlowInput = function ({ interval, generic, time, type, store, value, s
 const CashFlowRow = function ({ generic, client, storeComplex, children, labelInfo, type, time }) {
 
   var lefter  = { width: '7em', marginRight: '.2em' },
-      righter = { width: '7em', marginRight: '.9em' },
-      time    = time,
-      sharedProps = {
-        type: type, time: time,
-        store: storeComplex, generic: generic
-      };
+      righter = { width: '7em', marginRight: '.9em' };
 
   /** baseVal
   * Get the time ('current' or 'previous') monthly value unless there is
@@ -418,8 +411,7 @@ const CashFlowRow = function ({ generic, client, storeComplex, children, labelIn
   * value. What if some of the row's values are the same and some are
   * different?
   */
-  var generic     = generic,
-      intervalID  = generic + 'Monthly',
+  var intervalID  = generic + 'Monthly',
       baseVal     = client[ time + intervalID ];
 
   if ( !baseVal ) { baseVal = client[ 'previous' + intervalID ] || ''; }

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -322,7 +322,7 @@ const ColumnHeading = function ({ type, colName, style, children }) {
 * 
 * @function
 * @param {object} props
-* @property {object} __ - explanation
+* @property {object} props.__ - explanation
 * 
 * @returns Component
 */
@@ -355,7 +355,7 @@ const IntervalColumnHeadings = function ({ type }) {
 * 
 * @function
 * @param {object} props
-* @property {object} __ - explanation
+* @property {object} props.__ - explanation
 * 
 * @returns Component
 */
@@ -391,7 +391,7 @@ const CashFlowInput = function ({ interval, generic, time, type, store, value, s
 * 
 * @function
 * @param {object} props
-* @property {object} __ - explanation
+* @property {object} props.__ - explanation
 * 
 * @returns Component
 */

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -14,7 +14,6 @@ import {
 } from 'semantic-ui-react';
 
 // UTILITIES
-import { merge } from '../helpers/object-manipulation';
 import { roundMoney, limit, toMonthlyAmount } from '../helpers/math';
 
 
@@ -142,7 +141,7 @@ const FormPartsContainer = function(props) {
 * 
 * @returns Component
 */
-const MassiveToggle = function ( props ) {
+const MassiveToggle = function (props) {
 
   var time = props.time || '';
 
@@ -192,17 +191,17 @@ const FormSubheading = function ( props ) {
 * 
 * @returns Component
 */
-const FormHeading = function ( props ) {
+const FormHeading = function ({ subheading, children }) {
 
-  if ( !props.children ) { return null; }
+  if ( !children ) { return null; }
 
   return (
     <wrapper className={'form-heading'} >
       <div></div> {/** div here to make sure header margin doesn\'t collapse */}
       <Header as='h3' style={{ display: 'inline-block' }}>
-        { props.children }
+        { children }
       </Header>
-      <FormSubheading>{ props.subheading }</FormSubheading>
+      <FormSubheading>{subheading}</FormSubheading>
       <br/>
     </wrapper>
   );
@@ -313,10 +312,10 @@ const InlineLabelInfo = function ( props ) {
 * 
 * @returns Component
 */
-const ColumnHeading = function ( props ) {
-  var classes = props.type + '-column header ' + props.colName;
+const ColumnHeading = function ({ type, colName, style, children }) {
+  var classes = type + '-column header ' + colName;
   return (
-    <Header as='h4' className={classes} style={props.style} color='teal'>{ props.children }</Header>
+    <Header as='h4' className={classes} style={style} color='teal'>{children}</Header>
   );
 };  // End ColumnHeading()
 
@@ -325,26 +324,26 @@ const ColumnHeading = function ( props ) {
 * 
 * @function
 * @param {object} props
-* @property {object} props.__ - explanation
+* @property {object} __ - explanation
 * 
 * @returns Component
 */
-const IntervalColumnHeadings = function ( props ) {
+const IntervalColumnHeadings = function ({ type }) {
 
   var baseStyles  = {
         marginTop: '0.7em', marginBottom: '0.7em',
         display: 'inline-block', fontSize: '14px'
       },
-      inputStyles  = merge( { width: '7em', textAlign: 'center' }, baseStyles  ),
-      lefterStyles = merge( { marginRight: '0.2em' }, inputStyles ),
-      rightStyles  = merge( { marginRight: '0.9em' }, inputStyles );
+      inputStyles  = { ...baseStyles, width: '7em', textAlign: 'center' },
+      lefterStyles = { ...inputStyles, marginRight: '0.2em' },
+      rightStyles  = { ...inputStyles, marginRight: '0.9em' };
 
   return (
     <wrapper style={{ display: 'inline-block' }}>
-      <ColumnHeading type={props.type} colName='weekly'  style={lefterStyles}>Weekly</ColumnHeading>
-      <ColumnHeading type={props.type} colName='monthly' style={lefterStyles}>Monthly</ColumnHeading>
-      <ColumnHeading type={props.type} colName='yearly'  style={rightStyles}>Yearly</ColumnHeading>
-      <ColumnHeading type={props.type} colName={props.type} style={baseStyles}>Expense Type</ColumnHeading>
+      <ColumnHeading type={type} colName='weekly'  style={lefterStyles}>Weekly</ColumnHeading>
+      <ColumnHeading type={type} colName='monthly' style={lefterStyles}>Monthly</ColumnHeading>
+      <ColumnHeading type={type} colName='yearly'  style={rightStyles}>Yearly</ColumnHeading>
+      <ColumnHeading type={type} colName={type} style={baseStyles}>Expense Type</ColumnHeading>
     </wrapper>
   );
 
@@ -358,22 +357,19 @@ const IntervalColumnHeadings = function ( props ) {
 * 
 * @function
 * @param {object} props
-* @property {object} props.__ - explanation
+* @property {object} __ - explanation
 * 
 * @returns Component
 */
-const CashFlowInput = function ( props ) {
+const CashFlowInput = function ({ interval, generic, time, type, store, value, style, id, name }) {
 
-  /**
-  * Needs: interval, generic, time, store, type, value, style, id
-  */
   var handleChange = function ( evnt, inputProps ) {
 
-    var name    = props.time + props.generic + 'Monthly',
-        monthly = toMonthlyAmount[ props.interval ]( evnt, evnt.target.value ),
+    var name    = time + generic + 'Monthly',
+        monthly = toMonthlyAmount[ interval ]( evnt, evnt.target.value ),
         obj     = { name: name , value: monthly };
 
-    props.store( evnt, obj );
+    store( evnt, obj );
 
   };  // End handleChange()
 
@@ -381,11 +377,11 @@ const CashFlowInput = function ( props ) {
 
   return (
     <Input
-      className = { props.type + ' cashflow-column ' + props.interval }
+      className = { type + ' cashflow-column ' + interval }
       onChange  = { handleChange }
-      value     = { props.value }
-      style     = { props.style }
-      name      = { props.name }
+      value     = { value }
+      style     = { style }
+      name      = { name }
       type      = { 'number' } step = { '0.01' } min = { '0' }
     />
   );
@@ -397,21 +393,18 @@ const CashFlowInput = function ( props ) {
 * 
 * @function
 * @param {object} props
-* @property {object} props.__ - explanation
+* @property {object} __ - explanation
 * 
 * @returns Component
 */
-const CashFlowRow = function ( props ) {
-  /**
-  * Needs: generic, client, store, children, labelInfo, type, time
-  */
+const CashFlowRow = function ({ generic, client, storeComplex, children, labelInfo, type, time }) {
 
   var lefter  = { width: '7em', marginRight: '.2em' },
       righter = { width: '7em', marginRight: '.9em' },
-      time    = props.time,
+      time    = time,
       sharedProps = {
-        type: props.type, time: time,
-        store: props.storeComplex, generic: generic
+        type: type, time: time,
+        store: storeComplex, generic: generic
       };
 
   /** baseVal
@@ -425,50 +418,50 @@ const CashFlowRow = function ( props ) {
   * value. What if some of the row's values are the same and some are
   * different?
   */
-  var generic     = props.generic,
+  var generic     = generic,
       intervalID  = generic + 'Monthly',
-      baseVal     = props.client[ time + intervalID ];
+      baseVal     = client[ time + intervalID ];
 
-  if ( !baseVal ) { baseVal = props.client[ 'previous' + intervalID ] || ''; }
+  if ( !baseVal ) { baseVal = client[ 'previous' + intervalID ] || ''; }
 
-  // Could use `capitalizeWord()` in CashFlowInput to use `props.type`
+  // Could use `capitalizeWord()` in CashFlowInput to use `type`
   // to get id, but doesn't seem worth it at the moment.
   // Maybe put some of these in an object?
   return (
     <Form.Field inline>
       <CashFlowInput
-        type     = { props.type }
-        time     = { props.time }
+        type     = { type }
+        time     = { time }
         interval = { 'weekly' }
         value    = { roundMoney( baseVal / 4.33 ) || '' }
-        store    = { props.storeComplex }
+        store    = { storeComplex }
         generic  = { generic }
         name     = { time + generic + 'Weekly' }
         style    = { lefter }
       />
       <CashFlowInput
-        type     = { props.type }
-        time     = { props.time }
+        type     = { type }
+        time     = { time }
         interval = { 'monthly' }
         value    = { roundMoney( baseVal ) || '' }
-        store    = { props.storeComplex }
+        store    = { storeComplex }
         generic  = { generic }
         name     = { time + generic + 'Monthly' }
         style    = { lefter }
       />
       <CashFlowInput
-        type     = { props.type }
-        time     = { props.time }
+        type     = { type }
+        time     = { time }
         interval = { 'yearly' }
         value    = { roundMoney( baseVal * 12 ) || '' }
-        store    = { props.storeComplex }
+        store    = { storeComplex }
         generic  = { generic }
         name     = { time + generic + 'Yearly' }
         style    = { righter }
       />
       <wrapper>
-        <label>{ props.children }</label>
-        <InlineLabelInfo>{ props.labelInfo }</InlineLabelInfo>
+        <label>{ children }</label>
+        <InlineLabelInfo>{ labelInfo }</InlineLabelInfo>
       </wrapper>
     </Form.Field>
   );

--- a/src/forms/health.js
+++ b/src/forms/health.js
@@ -16,15 +16,15 @@ import {
 * 
 * @returns Component
 */
-const HealthContent = (props) => {
+const HealthContent = ({ storeChecked, client }) => {
 
   return (
     <wrapper>
 
       <MassiveToggle
-        label={props.client.qualifyingConditions ? {children: 'Yes'} : {children: 'No'}}
-        checked={props.client.qualifyingConditions}
-        onChange={props.storeChecked}
+        label={client.qualifyingConditions ? {children: 'Yes'} : {children: 'No'}}
+        checked={client.qualifyingConditions}
+        onChange={storeChecked}
         name='qualifyingConditions'
       />
 

--- a/src/forms/health.js
+++ b/src/forms/health.js
@@ -18,14 +18,12 @@ import {
 */
 const HealthContent = (props) => {
 
-  var client = props.pageState;
-
   return (
     <wrapper>
 
       <MassiveToggle
-        label={client.qualifyingConditions ? {children: 'Yes'} : {children: 'No'}}
-        checked={client.qualifyingConditions}
+        label={props.client.qualifyingConditions ? {children: 'Yes'} : {children: 'No'}}
+        checked={props.client.qualifyingConditions}
         onChange={props.storeChecked}
         name='qualifyingConditions'
       />
@@ -61,7 +59,7 @@ const HealthStep = function ( props ) {
         clarifier = {'Do you have any of the following MassHealth qualifying conditions?'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <HealthContent {...props}/>
+			<HealthContent storeChecked={props.storeChecked} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/health.js
+++ b/src/forms/health.js
@@ -18,8 +18,7 @@ import {
 */
 const HealthContent = (props) => {
 
-  var origin = props.origin,
-      client = origin.pageState;
+  var client = props.pageState;
 
   return (
     <wrapper>
@@ -27,7 +26,7 @@ const HealthContent = (props) => {
       <MassiveToggle
         label={client.qualifyingConditions ? {children: 'Yes'} : {children: 'No'}}
         checked={client.qualifyingConditions}
-        onChange={origin.storeChecked}
+        onChange={props.storeChecked}
         name='qualifyingConditions'
       />
 
@@ -62,7 +61,7 @@ const HealthStep = function ( props ) {
         clarifier = {'Do you have any of the following MassHealth qualifying conditions?'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <HealthContent origin={props}/>
+          <HealthContent {...props}/>
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/health.js
+++ b/src/forms/health.js
@@ -1,5 +1,5 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Segment } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS

--- a/src/forms/household-size.js
+++ b/src/forms/household-size.js
@@ -24,8 +24,7 @@ import { limit } from '../helpers/math';
 */
 const HouseholdSizeContent = (props) => {
 
-  var origin = props.origin,
-      client = origin.pageState,
+  var client = props.pageState,
       time   = 'previous';
 
 
@@ -34,11 +33,11 @@ const HouseholdSizeContent = (props) => {
 
     var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    origin.storeComplex( evnt, inputProps );
+    props.storeComplex( evnt, inputProps );
 
   };  // End ensureCurrComplex()
 
@@ -48,11 +47,11 @@ const HouseholdSizeContent = (props) => {
     
     var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      origin.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+      props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
 
     // Do the usual thing too
-    origin.storeChecked( evnt, inputProps );
+    props.storeChecked( evnt, inputProps );
 
   };  // End ensureCurrChecked()
 
@@ -73,7 +72,7 @@ const HouseholdSizeContent = (props) => {
             name='householdSize'
             value={size}
             checked={client.householdSize === size}
-            onChange={origin.storeComplex}
+            onChange={props.storeComplex}
           />
         </Form.Field>)
       )*/}
@@ -150,7 +149,7 @@ const HouseholdSizeStep = function ( props ) {
         clarifier = {'Information about the members of the household.'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <HouseholdSizeContent origin={props}/>
+          <HouseholdSizeContent {...props}/>
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/household-size.js
+++ b/src/forms/household-size.js
@@ -22,7 +22,7 @@ import { limit } from '../helpers/math';
 * 
 * @returns Component
 */
-const HouseholdSizeContent = (props) => {
+const HouseholdSizeContent = ({ storeChecked, storeComplex, client }) => {
 
   var time   = 'previous';
 
@@ -31,12 +31,12 @@ const HouseholdSizeContent = (props) => {
   var ensureCurrComplex = function ( evnt, inputProps ) {
 
     var keyOfCurr = inputProps.name.replace( 'previous', 'current' );
-    if ( !props.client[ keyOfCurr ] ) {
-      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+    if ( !client[ keyOfCurr ] ) {
+      storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    props.storeComplex( evnt, inputProps );
+    storeComplex( evnt, inputProps );
 
   };  // End ensureCurrComplex()
 
@@ -45,12 +45,12 @@ const HouseholdSizeContent = (props) => {
   var ensureCurrChecked = function ( evnt, inputProps ) {
     
     var keyOfCurr = inputProps.name.replace( 'previous', 'current' );
-    if ( !props.client[ keyOfCurr ] ) {
-      props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+    if ( !client[ keyOfCurr ] ) {
+      storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
 
     // Do the usual thing too
-    props.storeChecked( evnt, inputProps );
+    storeChecked( evnt, inputProps );
 
   };  // End ensureCurrChecked()
 
@@ -70,7 +70,7 @@ const HouseholdSizeContent = (props) => {
             label={size}
             name='householdSize'
             value={size}
-            checked={props.client.householdSize === size}
+            checked={client.householdSize === size}
             onChange={props.storeComplex}
           />
         </Form.Field>)
@@ -80,7 +80,7 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'HouseholdSize'}
           onChange  = {numberChange}
-          value     = {props.client[ time + 'HouseholdSize' ] || 1}
+          value     = {client[ time + 'HouseholdSize' ] || 1}
           name      = {time + 'HouseholdSize'}
           type={'number'} step={1} min={1} max={8} />
         <wrapper>
@@ -93,9 +93,9 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'Dependents'}
           onChange  = {numberChange}
-          value     = {props.client[ time + 'Dependents' ] || ''}
+          value     = {client[ time + 'Dependents' ] || ''}
           name      = {time + 'Dependents'}
-          type={'number'} step={1} min={0} max={props.client[ time + 'HouseholdSize' ] - 1} />
+          type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
         <wrapper>
           <label>Number of dependents</label>
           <InlineLabelInfo>Members that are under 18, disabled, handicapped, and/or a full-time student. Cannot include the head of household, their spouse, or foster children.</InlineLabelInfo>
@@ -106,20 +106,20 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'ChildrenUnder12'}
           onChange  = {numberChange}
-          value     = {props.client[ time + 'ChildrenUnder12' ] || ''}
+          value     = {client[ time + 'ChildrenUnder12' ] || ''}
           name      = {time + 'ChildrenUnder12'}
-          type={'number'} step={1} min={0} max={props.client[ time + 'HouseholdSize' ] - 1} />
+          type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
         <wrapper>
           <label>Number of children under 12</label>
         </wrapper>
       </Form.Field>
 
-      <MassiveToggle name={time + 'DisabledOrElderlyHeadOrSpouse'} value={props.client[ time + 'DisabledOrElderlyHeadOrSpouse' ]}
+      <MassiveToggle name={time + 'DisabledOrElderlyHeadOrSpouse'} value={client[ time + 'DisabledOrElderlyHeadOrSpouse' ]}
         storeChecked={ensureCurrChecked}
         label={'Was the head of household or their spouse considered disabled, handicapped, or elderly (62 or older)?'} />
 
       {/** Really should be split into disabled under 12 and other disabled? */}
-      <MassiveToggle name={time + 'DisabledOrElderlyMember'} value={props.client[ time + 'DisabledOrElderlyMember' ]}
+      <MassiveToggle name={time + 'DisabledOrElderlyMember'} value={client[ time + 'DisabledOrElderlyMember' ]}
         storeChecked={ensureCurrChecked}
         label={'Was any other household member, including children, considered disabled, handicapped, or elderly (62 or older)?'} />
 
@@ -145,7 +145,7 @@ const HouseholdSizeStep = function ( props ) {
         clarifier = {'Information about the members of the household.'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-<HouseholdSizeContent storeChecked={props.storeChecked} storeComplex={props.storeComplex} client={props.pageState} />
+			<HouseholdSizeContent storeChecked={props.storeChecked} storeComplex={props.storeComplex} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/household-size.js
+++ b/src/forms/household-size.js
@@ -24,15 +24,14 @@ import { limit } from '../helpers/math';
 */
 const HouseholdSizeContent = (props) => {
 
-  var client = props.pageState,
-      time   = 'previous';
+  var time   = 'previous';
 
 
   /** Makes sure values are propagated to 'current' properties if needed */
   var ensureCurrComplex = function ( evnt, inputProps ) {
 
     var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
-    if ( !client[ keyOfCurr ] ) {
+    if ( !props.client[ keyOfCurr ] ) {
       props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
@@ -46,7 +45,7 @@ const HouseholdSizeContent = (props) => {
   var ensureCurrChecked = function ( evnt, inputProps ) {
     
     var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
-    if ( !client[ keyOfCurr ] ) {
+    if ( !props.client[ keyOfCurr ] ) {
       props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
 
@@ -71,7 +70,7 @@ const HouseholdSizeContent = (props) => {
             label={size}
             name='householdSize'
             value={size}
-            checked={client.householdSize === size}
+            checked={props.client.householdSize === size}
             onChange={props.storeComplex}
           />
         </Form.Field>)
@@ -81,7 +80,7 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'HouseholdSize'}
           onChange  = {numberChange}
-          value     = {client[ time + 'HouseholdSize' ] || 1}
+          value     = {props.client[ time + 'HouseholdSize' ] || 1}
           name      = {time + 'HouseholdSize'}
           id        = {time + 'HouseholdSize'}
           type={'number'} step={1} min={1} max={8} />
@@ -95,10 +94,10 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'Dependents'}
           onChange  = {numberChange}
-          value     = {client[ time + 'Dependents' ] || ''}
+          value     = {props.client[ time + 'Dependents' ] || ''}
           name      = {time + 'Dependents'}
           id        = {time + 'Dependents'}
-          type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
+          type={'number'} step={1} min={0} max={props.client[ time + 'HouseholdSize' ] - 1} />
         <wrapper>
           <label>Number of dependents</label>
           <InlineLabelInfo>Members that are under 18, disabled, handicapped, and/or a full-time student. Cannot include the head of household, their spouse, or foster children.</InlineLabelInfo>
@@ -109,21 +108,21 @@ const HouseholdSizeContent = (props) => {
         <Input
           className = {time + 'ChildrenUnder12'}
           onChange  = {numberChange}
-          value     = {client[ time + 'ChildrenUnder12' ] || ''}
+          value     = {props.client[ time + 'ChildrenUnder12' ] || ''}
           name      = {time + 'ChildrenUnder12'}
           id        = {time + 'ChildrenUnder12'}
-          type={'number'} step={1} min={0} max={client[ time + 'HouseholdSize' ] - 1} />
+          type={'number'} step={1} min={0} max={props.client[ time + 'HouseholdSize' ] - 1} />
         <wrapper>
           <label>Number of children under 12</label>
         </wrapper>
       </Form.Field>
 
-      <MassiveToggle id={time + 'DisabledOrElderlyHeadOrSpouse'} value={client[ time + 'DisabledOrElderlyHeadOrSpouse' ]}
+      <MassiveToggle id={time + 'DisabledOrElderlyHeadOrSpouse'} value={props.client[ time + 'DisabledOrElderlyHeadOrSpouse' ]}
         storeChecked={ensureCurrChecked}
         label={'Was the head of household or their spouse considered disabled, handicapped, or elderly (62 or older)?'} />
 
       {/** Really should be split into disabled under 12 and other disabled? */}
-      <MassiveToggle id={time + 'DisabledOrElderlyMember'} value={client[ time + 'DisabledOrElderlyMember' ]}
+      <MassiveToggle id={time + 'DisabledOrElderlyMember'} value={props.client[ time + 'DisabledOrElderlyMember' ]}
         storeChecked={ensureCurrChecked}
         label={'Was any other household member, including children, considered disabled, handicapped, or elderly (62 or older)?'} />
 
@@ -149,7 +148,7 @@ const HouseholdSizeStep = function ( props ) {
         clarifier = {'Information about the members of the household.'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <HouseholdSizeContent {...props}/>
+<HouseholdSizeContent storeChecked={props.storeChecked} storeComplex={props.storeComplex} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/household-size.js
+++ b/src/forms/household-size.js
@@ -1,5 +1,5 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
+import React from 'react';
 import {
   Form, Input, // Radio
 } from 'semantic-ui-react';

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -59,8 +59,7 @@ const Housing = function ({ client, type, time, storeComplex, storeChecked }) {
   };  // End ensureCurrChecked()
 
 
-  let componentStoreChecked  = ensureCurrChecked,
-      sharedProps   = {
+  let sharedProps   = {
         client: client, type: type, time: time,
         storeComplex: ensureCurrComplex
       };
@@ -91,12 +90,12 @@ const Housing = function ({ client, type, time, storeComplex, storeChecked }) {
       */}
       <FormHeading>Shelter</FormHeading>
 
-      <MassiveToggle name={ time + 'Homeless' } value={ wasHomeless } storeChecked={ componentStoreChecked }
+      <MassiveToggle name={ time + 'Homeless' } value={ wasHomeless } storeChecked={ ensureCurrChecked }
           label='Was the household homeless at the last benefit assessment?' />
       { wasHomeless
         ? null
         : <MassiveToggle name={ time + 'Homeowner' } value={ ownedAHome }
-            storeChecked={ componentStoreChecked } label='Did the household own a home?' />
+            storeChecked={ ensureCurrChecked } label='Did the household own a home?' />
       }
       { !ownedAHome
         ? null
@@ -131,16 +130,16 @@ const Housing = function ({ client, type, time, storeComplex, storeChecked }) {
           {/** No padding for an element all on its own */}
           <br/>
 
-          <MassiveToggle name={ time + 'PaidUtilities' } value={ utils } storeChecked={ componentStoreChecked }
+          <MassiveToggle name={ time + 'PaidUtilities' } value={ utils } storeChecked={ ensureCurrChecked }
             label='Did the household pay utilities seperately from the rent?' />
           { !client[ time + 'PaidUtilities' ]
             ? null
             : <wrapper>
-              <MassiveToggle name={ time + 'ClimateControl' } value={ climate } storeChecked={ componentStoreChecked }
+              <MassiveToggle name={ time + 'ClimateControl' } value={ climate } storeChecked={ ensureCurrChecked }
                 label='Did the household pay for heating or cooling (e.g. A/C during summer), OR did they receive Fuel Assistance in the 12 months prior to the previous benefit assessment?' />
-              <MassiveToggle name={ time + 'NonHeatElectricity' } value={ electricity } storeChecked={ componentStoreChecked }
+              <MassiveToggle name={ time + 'NonHeatElectricity' } value={ electricity } storeChecked={ ensureCurrChecked }
                 label='Did the household pay for electricity for non-heating purposes?' />
-              <MassiveToggle name={ time + 'Phone' } value={ phone } storeChecked={ componentStoreChecked }
+              <MassiveToggle name={ time + 'Phone' } value={ phone } storeChecked={ ensureCurrChecked }
                 label='Did the household pay for its own telephone service?' />
             </wrapper>
           }

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -37,12 +37,7 @@ const Housing = function ( props ) {
   /** Makes sure values are propagated to 'current' properties if needed */
   let ensureCurrComplex = function ( evnt, inputProps ) {
     
-<<<<<<< HEAD
-
     let keyOfCurr = inputProps.name.replace( 'previous', 'current' );
-=======
-    let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
->>>>>>> 2097f11f7ef1608d0fbf3c3db939d5077e6d7c2c
     if ( !client[ keyOfCurr ] ) {
       props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
@@ -55,12 +50,8 @@ const Housing = function ( props ) {
 
   /** Makes sure values are propagated to 'current' properties if needed */
   let ensureCurrChecked = function ( evnt, inputProps ) {
-    
-<<<<<<< HEAD
+
 	let keyOfCurr = inputProps.name.replace( 'previous', 'current' );
-=======
-    let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
->>>>>>> 2097f11f7ef1608d0fbf3c3db939d5077e6d7c2c
     if ( !client[ keyOfCurr ] ) {
       props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -330,7 +330,7 @@ const ExpensesFormContent = function ( props ) {
 * 
 * @returns Component
 */
-// `props` is a cloned version of the propsal props. References broken.
+// `props` is a cloned version of the original props. References broken.
 const PreviousExpensesStep = function ( props ) {
 
   return (

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -22,8 +22,7 @@ import {
 */
 const Housing = function ( props ) {
 
-  let origin        = props.props,
-      client        = origin.pageState,
+  let client        = props.pageState,
       time          = props.time;
 
   // `hasHousing` is actually whether they're in the housing voucher program
@@ -40,11 +39,11 @@ const Housing = function ( props ) {
     
     let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    origin.storeComplex( evnt, inputProps );
+    props.storeComplex( evnt, inputProps );
 
   };  // End ensureCurrComplex()
 
@@ -54,11 +53,11 @@ const Housing = function ( props ) {
     
     let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      origin.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+      props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
 
     // Do the usual thing too
-    origin.storeChecked( evnt, inputProps );
+    props.storeChecked( evnt, inputProps );
 
   };  // End ensureCurrChecked()
 
@@ -96,11 +95,11 @@ const Housing = function ( props ) {
       <FormHeading>Shelter</FormHeading>
 
       <MassiveToggle id={ time + 'Homeless' } value={ wasHomeless } storeChecked={ storeChecked }
-          label={'Was the household homeless at the last benefit assessment?'}/>
+          label='Was the household homeless at the last benefit assessment?' />
       { wasHomeless
         ? null
         : <MassiveToggle id={ time + 'Homeowner' } value={ ownedAHome }
-            storeChecked={ storeChecked } label={ 'Did the household own a home?' } />
+            storeChecked={ storeChecked } label='Did the household own a home?' />
       }
       { !ownedAHome
         ? null
@@ -109,9 +108,9 @@ const Housing = function ( props ) {
           <FormHeading>Homeowner</FormHeading>
 
           <IntervalColumnHeadings type={ props.type }/>
-          <CashFlowRow {...sharedProps} generic={'Mortgage'}> Mortgage </CashFlowRow>
-          <CashFlowRow {...sharedProps} generic={'HousingInsurance'}> Insurance Costs </CashFlowRow>
-          <CashFlowRow {...sharedProps} generic={'PropertyTax'}> Property Tax </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic='Mortgage'> Mortgage </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic='HousingInsurance'> Insurance Costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic='PropertyTax'> Property Tax </CashFlowRow>
         </wrapper>
       }
       { !rented
@@ -123,29 +122,29 @@ const Housing = function ( props ) {
           <IntervalColumnHeadings type={ props.type }/>
           { client.hasHousing
             ? <wrapper>
-              <CashFlowRow {...sharedProps} generic={'RentShare'}> Rent Share </CashFlowRow>
+              <CashFlowRow {...sharedProps} generic='RentShare'> Rent Share </CashFlowRow>
               <CashFlowRow {...sharedProps}
-                generic={'ContractRent'}
-                labeInfo={'The full amount the landord would charge without a Section 8 voucher'}>
+                generic='ContractRent'
+                labeInfo='The full amount the landord would charge without a Section 8 voucher'>
 				Contract Rent </CashFlowRow>
             </wrapper>
-            : <CashFlowRow {...sharedProps} generic={'Rent'}> Rent </CashFlowRow>
+            : <CashFlowRow {...sharedProps} generic='Rent'> Rent </CashFlowRow>
           }
           
           {/** No padding for an element all on its own */}
           <br/>
 
           <MassiveToggle id={ time + 'PaidUtilities' } value={ utils } storeChecked={ storeChecked }
-            label={'Did the household pay utilities seperately from the rent?'}/>
+            label='Did the household pay utilities seperately from the rent?' />
           { !client[ time + 'PaidUtilities' ]
             ? null
             : <wrapper>
               <MassiveToggle id={ time + 'ClimateControl' } value={ climate } storeChecked={ storeChecked }
                 label={'Did the household pay for heating or cooling (e.g. A/C during summer), OR did they receive Fuel Assistance in the 12 months prior to the previous benefit assessment?'}/>
               <MassiveToggle id={ time + 'NonHeatElectricity' } value={ electricity } storeChecked={ storeChecked }
-                label={'Did the household pay for electricity for non-heating purposes?'}/>
+                label='Did the household pay for electricity for non-heating purposes?' />
               <MassiveToggle id={ time + 'Phone' } value={ phone } storeChecked={ storeChecked }
-                label={'Did the household pay for its own telephone service?'}/>
+                label='Did the household pay for its own telephone service?' />
             </wrapper>
           }
         </wrapper>
@@ -170,15 +169,14 @@ const Housing = function ( props ) {
 const ExpensesFormContent = function ( props ) {
 
   let client        = props.client,
-      origin        = props.props,
-      storeChecked  = origin.storeChecked,
+      storeChecked  = props.storeChecked,
       time          = 'previous', type = 'expense';
 
   let needsDisabledAssistance = client[ time + 'GettingDisabledAssistance' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ];
 
-  let sharedProps = { client: client, type: type, time: time, storeComplex: origin.storeComplex };
+  let sharedProps = { client: client, type: type, time: time, storeComplex: props.storeComplex };
 
   /** @todo 1) Can client only enter amounts not covered by other programs
   * for childcare expenses? 2) Does money from those programs count as income?
@@ -303,7 +301,7 @@ const ExpensesFormContent = function ( props ) {
         </wrapper>
       }
 
-      <Housing props={props.props} time={time} type={type}/>
+      <Housing {...props} time={time} type={type}/>
 
       <FormHeading>Other</FormHeading>
       <CashFlowRow {...sharedProps} generic={'OtherExpenses'}> Other Expenses </CashFlowRow>
@@ -332,7 +330,7 @@ const ExpensesFormContent = function ( props ) {
 * 
 * @returns Component
 */
-// `props` is a cloned version of the original props. References broken.
+// `props` is a cloned version of the propsal props. References broken.
 const PreviousExpensesStep = function ( props ) {
 
   return (
@@ -342,7 +340,7 @@ const PreviousExpensesStep = function ( props ) {
         clarifier = {'Monthly expenses that were expected to happen during the 12 months following that assessment'}
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-        <ExpensesFormContent client={props.pageState} props={props}/>
+        <ExpensesFormContent {...props} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -1,16 +1,11 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
-import { Form, Header, Statistic, Divider, Input } from 'semantic-ui-react';
+import React from 'react';
+import { Form } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
 import {
-  FormPartsContainer, MassiveToggle, FormHeading, InlineLabelInfo,
-  IntervalColumnHeadings, CashFlowRow
+  FormPartsContainer, MassiveToggle, FormHeading, IntervalColumnHeadings, CashFlowRow
 } from './formHelpers';
-
-// UTILITIES
-import { merge } from '../helpers/object-manipulation';
-import { roundMoney, limit } from '../helpers/math';
 
 
 // ========================================
@@ -27,23 +22,23 @@ import { roundMoney, limit } from '../helpers/math';
 */
 const Housing = function ( props ) {
 
-  var origin        = props.props,
+  let origin        = props.props,
       client        = origin.pageState,
       time          = props.time;
 
   // `hasHousing` is actually whether they're in the housing voucher program
-  var ownedAHome  = client[ time + 'Homeowner' ],
+  let ownedAHome  = client[ time + 'Homeowner' ],
       wasHomeless = client[ time + 'Homeless' ] && !client.hasHousing && !ownedAHome,
       rented      = !wasHomeless && !ownedAHome;
 
-  var utils = client[ time + 'PaidUtilities' ], climate = client[ time + 'GotClimateControl' ],
+  let utils = client[ time + 'PaidUtilities' ], climate = client[ time + 'GotClimateControl' ],
       electricity = client[ time + 'NonHeatElectricity' ], phone = client[ time + 'Phone' ];
 
 
   /** Makes sure values are propagated to 'current' properties if needed */
-  var ensureCurrComplex = function ( evnt, inputProps ) {
+  let ensureCurrComplex = function ( evnt, inputProps ) {
     
-    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
       origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
@@ -55,9 +50,9 @@ const Housing = function ( props ) {
 
 
   /** Makes sure values are propagated to 'current' properties if needed */
-  var ensureCurrChecked = function ( evnt, inputProps ) {
+  let ensureCurrChecked = function ( evnt, inputProps ) {
     
-    var keyOfCurr = inputProps.id.replace( 'previous', 'current' );
+    let keyOfCurr = inputProps.id.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
       origin.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
@@ -68,7 +63,7 @@ const Housing = function ( props ) {
   };  // End ensureCurrChecked()
 
 
-  var storeChecked  = ensureCurrChecked,
+  let storeChecked  = ensureCurrChecked,
       sharedProps   = {
         client: client, type: props.type, time: time,
         storeComplex: ensureCurrComplex
@@ -114,9 +109,9 @@ const Housing = function ( props ) {
           <FormHeading>Homeowner</FormHeading>
 
           <IntervalColumnHeadings type={ props.type }/>
-          <CashFlowRow {...merge( {generic: 'Mortgage'}, sharedProps )}> Mortgage </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'HousingInsurance'}, sharedProps )}> Insurance Costs </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'PropertyTax'}, sharedProps )}> Property Tax </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'Mortgage'}> Mortgage </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'HousingInsurance'}> Insurance Costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'PropertyTax'}> Property Tax </CashFlowRow>
         </wrapper>
       }
       { !rented
@@ -128,13 +123,13 @@ const Housing = function ( props ) {
           <IntervalColumnHeadings type={ props.type }/>
           { client.hasHousing
             ? <wrapper>
-              <CashFlowRow {...merge( {generic: 'RentShare'}, sharedProps )}> Rent Share </CashFlowRow>
-              <CashFlowRow {...merge(
-                { generic: 'ContractRent',
-                  labeInfo: 'The full amount the landord would charge without a Section 8 voucher'}
-                , sharedProps )}> Contract Rent </CashFlowRow>
+              <CashFlowRow {...sharedProps} generic={'RentShare'}> Rent Share </CashFlowRow>
+              <CashFlowRow {...sharedProps}
+                generic={'ContractRent'}
+                labeInfo={'The full amount the landord would charge without a Section 8 voucher'}>
+				Contract Rent </CashFlowRow>
             </wrapper>
-            : <CashFlowRow {...merge( {generic: 'Rent'}, sharedProps )}> Rent </CashFlowRow>
+            : <CashFlowRow {...sharedProps} generic={'Rent'}> Rent </CashFlowRow>
           }
           
           {/** No padding for an element all on its own */}
@@ -174,20 +169,16 @@ const Housing = function ( props ) {
 */
 const ExpensesFormContent = function ( props ) {
 
-  var client        = props.client,
+  let client        = props.client,
       origin        = props.props,
       storeChecked  = origin.storeChecked,
       time          = 'previous', type = 'expense';
 
-  var needsDisabledAssistance = client[ time + 'GettingDisabledAssistance' ]
+  let needsDisabledAssistance = client[ time + 'GettingDisabledAssistance' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ];
 
-  var time = 'previous', type = 'expense';
-  var sharedProps = { client: client, type: type, time: time,
-                    storeComplex: origin.storeComplex };
-  var incomeProps = merge( {}, sharedProps );
-  incomeProps.type = 'income';
+  let sharedProps = { client: client, type: type, time: time, storeComplex: origin.storeComplex };
 
   /** @todo 1) Can client only enter amounts not covered by other programs
   * for childcare expenses? 2) Does money from those programs count as income?
@@ -213,11 +204,11 @@ const ExpensesFormContent = function ( props ) {
           <FormHeading subheading = {'A "child" is a person 12 or younger. Don\'t include amounts that are paid for by other benefit programs.\n'}>
             Reasonable Unreimbursed Non-Medical Child(ren) Care</FormHeading>
           <IntervalColumnHeadings type={type}/>
-          <CashFlowRow {...merge( {generic: 'ChildDirectCareCosts'}, sharedProps )}> Direct care costs </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'ChildBeforeAndAfterSchoolCareCosts'}, sharedProps )}> Before- and after-school care </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'ChildTransportationCosts'}, sharedProps )}> Transportation costs </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'ChildOtherCareCosts'}, sharedProps )}> Other care </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'EarnedIncomeBecauseOfChildCare'}, incomeProps )}> <span style={{textDecoration: 'underline'}}>Income</span> made possible by child care expenses </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'ChildDirectCareCosts'}> Direct care costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'ChildBeforeAndAfterSchoolCareCosts'}> Before- and after-school care </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'ChildTransportationCosts'}> Transportation costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'ChildOtherCareCosts'}> Other care </CashFlowRow>
+          <CashFlowRow {...sharedProps} type={'income'} generic={'EarnedIncomeBecauseOfChildCare'}> <span style={{textDecoration: 'underline'}}>Income</span> made possible by child care expenses </CashFlowRow>
         </wrapper>
       }
 
@@ -226,7 +217,7 @@ const ExpensesFormContent = function ( props ) {
       <wrapper>
         <FormHeading>Child Support</FormHeading>
         <IntervalColumnHeadings type={type}/>
-        <CashFlowRow {...merge( {generic: 'ChildSupportPaidOut'}, sharedProps )}> LEGALLY OBLIGATED Child support paid out </CashFlowRow>
+        <CashFlowRow {...sharedProps} generic={'ChildSupportPaidOut'}> LEGALLY OBLIGATED Child support paid out </CashFlowRow>
       </wrapper>
 
       {/** 
@@ -242,9 +233,9 @@ const ExpensesFormContent = function ( props ) {
           <FormHeading subheading = {'A adult dependent is a person older than 12 and either disabled or 62 or older. Don\'t include amounts that are paid for by other benefit programs.\n'}>
             Disabled or Elderly Care</FormHeading>
           <IntervalColumnHeadings type={type}/>
-          <CashFlowRow {...merge( {generic: 'AdultDirectCareCosts'}, sharedProps )}> Direct care costs </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'AdultTransportationCosts'}, sharedProps )}> Transportation costs </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'AdultOtherCareCosts'}, sharedProps )}> Other care </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'AdultDirectCareCosts'}> Direct care costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'AdultTransportationCosts'}> Transportation costs </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'AdultOtherCareCosts'}> Other care </CashFlowRow>
         </wrapper>
       }
 
@@ -268,8 +259,8 @@ const ExpensesFormContent = function ( props ) {
             <li>Payments to a care attendant to stay with a disabled 16-year-old child allow the child’s mother to go to work every day. These payments are an eligible disability assistance allowance.</li>
           </ul>
           <IntervalColumnHeadings type={type}/>
-          <CashFlowRow {...merge( {generic: 'DisabledAssistance'}, sharedProps )}> Disabled/Handicapped assistance </CashFlowRow>
-          <CashFlowRow {...merge( {generic: 'EarnedIncomeBecauseOfAdultCare'}, incomeProps )}> <span style={{textDecoration: 'underline'}}>Income</span> made possible by assistance expenses </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'DisabledAssistance'}> Disabled/Handicapped assistance </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'EarnedIncomeBecauseOfAdultCare'}> <span style={{textDecoration: 'underline'}}>Income</span> made possible by assistance expenses </CashFlowRow>
         </wrapper>
       }
 
@@ -308,14 +299,14 @@ const ExpensesFormContent = function ( props ) {
             <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred). The allowance may include only the amount expected to be paid in the coming 12 months.</li>
           </ul>
           <IntervalColumnHeadings type={type}/>
-          <CashFlowRow {...merge( {generic: 'DisabledAssistance'}, sharedProps )}> Disabled/Handicapped/Elderly assistance </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic={'DisabledAssistance'}> Disabled/Handicapped/Elderly assistance </CashFlowRow>
         </wrapper>
       }
 
       <Housing props={props.props} time={time} type={type}/>
 
       <FormHeading>Other</FormHeading>
-      <CashFlowRow {...merge( {generic: 'OtherExpenses'}, sharedProps )}> Other Expenses </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'OtherExpenses'}> Other Expenses </CashFlowRow>
 
     </wrapper>
   );

--- a/src/forms/previousExpenses.js
+++ b/src/forms/previousExpenses.js
@@ -20,10 +20,7 @@ import {
 * 
 * @returns Component
 */
-const Housing = function ( props ) {
-
-  let client        = props.pageState,
-      time          = props.time;
+const Housing = function ({ client, type, time, storeComplex, storeChecked }) {
 
   // `hasHousing` is actually whether they're in the housing voucher program
   let ownedAHome  = client[ time + 'Homeowner' ],
@@ -39,11 +36,11 @@ const Housing = function ( props ) {
     
     let keyOfCurr = inputProps.name.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+      storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    props.storeComplex( evnt, inputProps );
+    storeComplex( evnt, inputProps );
 
   };  // End ensureCurrComplex()
 
@@ -53,18 +50,18 @@ const Housing = function ( props ) {
 
 	let keyOfCurr = inputProps.name.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      props.storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
+      storeChecked( evnt, { name: keyOfCurr, checked: inputProps.checked } );
     }
 
     // Do the usual thing too
-    props.storeChecked( evnt, inputProps );
+    storeChecked( evnt, inputProps );
 
   };  // End ensureCurrChecked()
 
 
-  let storeChecked  = ensureCurrChecked,
+  let componentStoreChecked  = ensureCurrChecked,
       sharedProps   = {
-        client: client, type: props.type, time: time,
+        client: client, type: type, time: time,
         storeComplex: ensureCurrComplex
       };
 
@@ -94,12 +91,12 @@ const Housing = function ( props ) {
       */}
       <FormHeading>Shelter</FormHeading>
 
-      <MassiveToggle name={ time + 'Homeless' } value={ wasHomeless } storeChecked={ storeChecked }
+      <MassiveToggle name={ time + 'Homeless' } value={ wasHomeless } storeChecked={ componentStoreChecked }
           label='Was the household homeless at the last benefit assessment?' />
       { wasHomeless
         ? null
         : <MassiveToggle name={ time + 'Homeowner' } value={ ownedAHome }
-            storeChecked={ storeChecked } label='Did the household own a home?' />
+            storeChecked={ componentStoreChecked } label='Did the household own a home?' />
       }
       { !ownedAHome
         ? null
@@ -107,7 +104,7 @@ const Housing = function ( props ) {
 
           <FormHeading>Homeowner</FormHeading>
 
-          <IntervalColumnHeadings type={ props.type }/>
+          <IntervalColumnHeadings type={ type }/>
           <CashFlowRow {...sharedProps} generic='Mortgage'> Mortgage </CashFlowRow>
           <CashFlowRow {...sharedProps} generic='HousingInsurance'> Insurance Costs </CashFlowRow>
           <CashFlowRow {...sharedProps} generic='PropertyTax'> Property Tax </CashFlowRow>
@@ -119,7 +116,7 @@ const Housing = function ( props ) {
 
           <FormHeading>Renter</FormHeading>
 
-          <IntervalColumnHeadings type={ props.type }/>
+          <IntervalColumnHeadings type={ type }/>
           { client.hasHousing
             ? <wrapper>
               <CashFlowRow {...sharedProps} generic='RentShare'> Rent Share </CashFlowRow>
@@ -134,16 +131,16 @@ const Housing = function ( props ) {
           {/** No padding for an element all on its own */}
           <br/>
 
-          <MassiveToggle name={ time + 'PaidUtilities' } value={ utils } storeChecked={ storeChecked }
+          <MassiveToggle name={ time + 'PaidUtilities' } value={ utils } storeChecked={ componentStoreChecked }
             label='Did the household pay utilities seperately from the rent?' />
           { !client[ time + 'PaidUtilities' ]
             ? null
             : <wrapper>
-              <MassiveToggle name={ time + 'ClimateControl' } value={ climate } storeChecked={ storeChecked }
+              <MassiveToggle name={ time + 'ClimateControl' } value={ climate } storeChecked={ componentStoreChecked }
                 label='Did the household pay for heating or cooling (e.g. A/C during summer), OR did they receive Fuel Assistance in the 12 months prior to the previous benefit assessment?' />
-              <MassiveToggle name={ time + 'NonHeatElectricity' } value={ electricity } storeChecked={ storeChecked }
+              <MassiveToggle name={ time + 'NonHeatElectricity' } value={ electricity } storeChecked={ componentStoreChecked }
                 label='Did the household pay for electricity for non-heating purposes?' />
-              <MassiveToggle name={ time + 'Phone' } value={ phone } storeChecked={ storeChecked }
+              <MassiveToggle name={ time + 'Phone' } value={ phone } storeChecked={ componentStoreChecked }
                 label='Did the household pay for its own telephone service?' />
             </wrapper>
           }
@@ -166,17 +163,17 @@ const Housing = function ( props ) {
 * 
 * @returns Component
 */
-const ExpensesFormContent = function ( props ) {
+const ExpensesFormContent = function ({ client, storeChecked, storeComplex }) {
 
-  let client        = props.client,
-      storeChecked  = props.storeChecked,
-      time          = 'previous', type = 'expense';
+  //let client        = props.client,
+  //    storeChecked  = props.storeChecked,
+  let time          = 'previous', type = 'expense';
 
   let needsDisabledAssistance = client[ time + 'GettingDisabledAssistance' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ]
     || client[ time + 'DisabledOrElderlyHeadOrSpouse' ];
 
-  let sharedProps = { client: client, type: type, time: time, storeComplex: props.storeComplex };
+  let sharedProps = { client: client, type: type, time: time, storeComplex: storeComplex };
 
   /** @todo 1) Can client only enter amounts not covered by other programs
   * for childcare expenses? 2) Does money from those programs count as income?
@@ -301,7 +298,7 @@ const ExpensesFormContent = function ( props ) {
         </wrapper>
       }
 
-      <Housing {...props} time={time} type={type}/>
+      <Housing client={client} time={time} type={type} storeChecked={storeChecked} storeComplex={storeComplex} />
 
       <FormHeading>Other</FormHeading>
       <CashFlowRow {...sharedProps} generic={'OtherExpenses'}> Other Expenses </CashFlowRow>

--- a/src/forms/previousIncome.js
+++ b/src/forms/previousIncome.js
@@ -45,8 +45,7 @@ const IncomeForm = function ( props ) {
 
   var time    = 'previous',
       type    = 'income',
-      client  = props.client,
-      origin  = props.props;
+      client  = props.client;
 
 
   /** Makes sure values are propagated to 'current' properties if needed */
@@ -54,39 +53,40 @@ const IncomeForm = function ( props ) {
     
     var keyOfCurr = inputProps.name.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      origin.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    origin.storeComplex( evnt, inputProps );
+    props.storeComplex( evnt, inputProps );
 
   };  // End ensureCurrent()
 
 
   var sharedProps = { client: client, type: type, time: time,
                       storeComplex: ensureCurrent };
-
+					  
   return (
     <div className='field-aligner two-column'>
 
       <IntervalColumnHeadings type={type}/>
 
       {/* All kinds of things need to be explained. */}
-      <CashFlowRow  {...sharedProps} generic={'EarnedIncome'} labelInfo={'(Weekly income = hourly wage times average number of work hours per week)'}>
+	  <CashFlowRow  {...sharedProps} generic='EarnedIncome' labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
           Earned income
-      </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'TAFDC'}> TAFDC </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'SSI'}> SSI </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'SSDI'}> SSDI </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'ChildSupportIn'}> Child support coming in </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'Unemployment'}> Unemployment </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'WorkersComp'}> Worker’s comp </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'Pension'}> Pension </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'SocialSecurity'}> Social security </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'Alimony'}> Alimony </CashFlowRow>
-      <CashFlowRow {...sharedProps} generic={'OtherIncome'}> Other income </CashFlowRow>
+		  </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='TAFDC'> TAFDC </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='TAFDC'> TAFDC </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='SSI'> SSI </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='SSDI'> SSDI </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='ChildSupportIn'> Child support coming in </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='Unemployment'> Unemployment </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='WorkersComp'> Worker’s comp </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='Pension'> Pension </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='SocialSecurity'> Social security </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='Alimony'> Alimony </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='OtherIncome'> Other income </CashFlowRow>
       <Divider/>
-      <CashFlowRow {...sharedProps} generic={'IncomeExclusions'}> Income exclusions </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic='IncomeExclusions'> Income exclusions </CashFlowRow>
 
     </div>
   );  // end return
@@ -113,7 +113,7 @@ const PreviousIncomeStep = function ( props ) {
         clarifier = 'Income that you expected to collect during the 12 months following the previous assessment'
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <IncomeForm client={props.pageState} props={props}/>
+          <IncomeForm {...props} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );

--- a/src/forms/previousIncome.js
+++ b/src/forms/previousIncome.js
@@ -1,14 +1,9 @@
 // REACT COMPONENTS
-import React, { Component } from 'react';
-import { Form, Header, Statistic, Divider } from 'semantic-ui-react';
+import React from 'react';
+import { Form, Divider } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
 import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formHelpers';
-
-// UTILITIES
-import { roundMoney, limit } from '../helpers/math';
-import { merge } from '../helpers/object-manipulation';
-
 
 /**
 * @todo Figure out which programs need to know which types of incomes
@@ -77,22 +72,21 @@ const IncomeForm = function ( props ) {
       <IntervalColumnHeadings type={type}/>
 
       {/* All kinds of things need to be explained. */}
-      <CashFlowRow {...merge( {generic: 'EarnedIncome',
-        labelInfo: '(Weekly income = hourly wage times average number of work hours per week)'}, sharedProps )}>
+      <CashFlowRow  {...sharedProps} generic={'EarnedIncome'} labelInfo={'(Weekly income = hourly wage times average number of work hours per week)'}>
           Earned income
       </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'TAFDC'} )}> TAFDC </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'SSI'} )}> SSI </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'SSDI'} )}> SSDI </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'ChildSupportIn'} )}> Child support coming in </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'Unemployment'} )}> Unemployment </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'WorkersComp'} )}> Worker’s comp </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'Pension'} )}> Pension </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'SocialSecurity'} )}> Social security </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'Alimony'} )}> Alimony </CashFlowRow>
-      <CashFlowRow {...merge( sharedProps, {generic: 'OtherIncome'} )}> Other income </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'TAFDC'}> TAFDC </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'SSI'}> SSI </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'SSDI'}> SSDI </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'ChildSupportIn'}> Child support coming in </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'Unemployment'}> Unemployment </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'WorkersComp'}> Worker’s comp </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'Pension'}> Pension </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'SocialSecurity'}> Social security </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'Alimony'}> Alimony </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'OtherIncome'}> Other income </CashFlowRow>
       <Divider/>
-      <CashFlowRow {...merge( sharedProps, {generic: 'IncomeExclusions'} )}> Income exclusions </CashFlowRow>
+      <CashFlowRow {...sharedProps} generic={'IncomeExclusions'}> Income exclusions </CashFlowRow>
 
     </div>
   );  // end return

--- a/src/forms/previousIncome.js
+++ b/src/forms/previousIncome.js
@@ -62,7 +62,7 @@ const IncomeForm = function ({ storeComplex, client }) {
 
   var sharedProps = { client: client, type: type, time: time,
                       storeComplex: ensureCurrent };
-					  
+
   return (
     <div className='field-aligner two-column'>
 

--- a/src/forms/previousIncome.js
+++ b/src/forms/previousIncome.js
@@ -41,23 +41,21 @@ import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formH
 * 
 * @returns Component
 */
-const IncomeForm = function ( props ) {
+const IncomeForm = function ({ storeComplex, client }) {
 
   var time    = 'previous',
-      type    = 'income',
-      client  = props.client;
-
+      type    = 'income'
 
   /** Makes sure values are propagated to 'current' properties if needed */
   var ensureCurrent = function ( evnt, inputProps ) {
     
     var keyOfCurr = inputProps.name.replace( 'previous', 'current' );
     if ( !client[ keyOfCurr ] ) {
-      props.storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
+      storeComplex( evnt, { name: keyOfCurr, value: inputProps.value } );
     }
 
     // Do the usual thing too
-    props.storeComplex( evnt, inputProps );
+    storeComplex( evnt, inputProps );
 
   };  // End ensureCurrent()
 
@@ -113,7 +111,7 @@ const PreviousIncomeStep = function ( props ) {
         clarifier = 'Income that you expected to collect during the 12 months following the previous assessment'
         left      = {{name: 'Previous', func: props.previousStep}}
         right     = {{name: 'Next', func: props.nextStep}}>
-          <IncomeForm {...props} client={props.pageState} />
+          <IncomeForm storeComplex={props.storeComplex} client={props.pageState} />
       </FormPartsContainer>
     </Form>
   );


### PR DESCRIPTION
Props for a React component should always be flat - there are no extra props inside objects. When passing down props from a parent component, the spread notation can be used or the specific props explicitly passed down. I also prefer using the spread notation to other ways to merge, but that's open for discussion.