### PR TITLE
[139] Return to React-Scripts Test Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ If you have questions, feel free to ask.
 
 ## Testing
 
-Testing the project is pretty straightforward! From the cliff-effects directory, run `npm run test`. That's it.
+We use [React-Scripts test command](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests) (which wraps the [Jest](https://facebook.github.io/jest/) test framework) to run our [automated test suite](https://en.wikipedia.org/wiki/Test_automation).
+
+To run our test suite, run `npm run test`. That will run any tests that have changed since the last commit, and boot up an interactive testing session. The interactive session will prompt you with instructions, but the most important commands are `a` to run all tests, and `q` to quit the interactive session.
+
+For information on how to *write* new tests, please refer to the [React-Scripts documentation](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#writing-tests) on the subject.
 
 ## Resources
 

--- a/package.json
+++ b/package.json
@@ -20,17 +20,14 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest",
+    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "deploy": "npm run build&&gh-pages -d build"
   },
   "homepage": "https://codeforboston.github.io/cliff-effects",
   "devDependencies": {
-    "babel-jest": "^21.2.0",
-    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "gh-pages": "^1.0.0",
-    "jest": "^21.2.1"
+    "gh-pages": "^1.0.0"
   },
   "description": "This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).",
   "main": "index.js",


### PR DESCRIPTION
Resolves #139 .

Resets us back to the normal React-Scripts test runner and updates the README with instructions. Note that not all tests are passing, but the same tests that failed before on vanilla Jest are still failing now.