### PR TITLE
Addresses #148, results as table

### DIFF
--- a/src/forms/BenefitsTable.js
+++ b/src/forms/BenefitsTable.js
@@ -1,0 +1,112 @@
+// REACT COMPONENTS
+import React from 'react';
+import {
+  Table,
+  Header
+} from 'semantic-ui-react';
+
+// Both the table and graph should just be added to a results page, but
+// this will do for now
+import ResultsGraph from '../resultsGraph';
+
+
+const getSignSymbol = function ( num ) {
+  if ( num > 0 ) { return '+'; }
+  else if ( num < 0 ) { return '-'; }
+  else { return ''; }
+};  // End getSignSymbol()
+
+
+const BenefitsTable = function ( props ) {
+
+  var SNAPBenefitCurrent = 100,
+      SNAPBenefitFuture = 90,
+      SNAPDiff = SNAPBenefitCurrent - SNAPBenefitFuture,
+      sec8BenefitCurrent = 90,
+      sec8BenefitFuture = 100,
+      sec8Diff = sec8BenefitCurrent - sec8BenefitFuture,
+      totalBenefitCurrent = SNAPBenefitCurrent + sec8BenefitCurrent,
+      totalBenefitFuture = SNAPBenefitFuture + sec8BenefitFuture,
+      totalDiff = SNAPDiff + sec8Diff,
+      incomeCurrent = 100,
+      incomeFuture = 200,
+      incomeDiff = incomeCurrent - incomeFuture,
+      netCurrent = totalBenefitCurrent + incomeCurrent,
+      netFuture = totalBenefitFuture + incomeFuture,
+      netDiff = totalDiff + incomeDiff;
+
+  return (
+    <wrapper>
+      <Table celled color='black'>
+
+        <Table.Header>
+          <Table.Row textAlign='center'>
+            <Table.HeaderCell width={3}>Program</Table.HeaderCell>
+            <Table.HeaderCell width={3}>Current Benefits</Table.HeaderCell>
+            <Table.HeaderCell width={3}>New Estimate</Table.HeaderCell>
+            <Table.HeaderCell width={3}>Difference</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell textAlign='left'><Header as='h4'>SNAP</Header></Table.Cell>
+            <Table.Cell textAlign='right'>${SNAPBenefitCurrent} / year</Table.Cell>
+            <Table.Cell textAlign='right'>${SNAPBenefitFuture} / year</Table.Cell>
+            <Table.Cell textAlign='right'>{ getSignSymbol(SNAPDiff) } ${Math.abs(SNAPDiff)} / year</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell textAlign='left'><Header as='h4'>Section 8 Housing</Header></Table.Cell>
+            <Table.Cell textAlign='right'>${sec8BenefitCurrent} / year</Table.Cell>
+            <Table.Cell textAlign='right'>${sec8BenefitFuture} / year</Table.Cell>
+            <Table.Cell textAlign='right'>{ getSignSymbol(sec8Diff) } ${Math.abs(sec8Diff)} / year</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+
+      </Table>
+
+      <Table celled color='black'>
+
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell width={3} textAlign='left'><Header as='h4'>Total Benefits</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>${totalBenefitCurrent} / year</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>${totalBenefitFuture} / year</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>{ getSignSymbol(totalDiff) } ${Math.abs(totalDiff)} / year</Header></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell textAlign='left'>Income</Table.Cell>
+            <Table.Cell textAlign='right'>${incomeCurrent} / year</Table.Cell>
+            <Table.Cell textAlign='right'>${incomeFuture} / year</Table.Cell>
+            <Table.Cell textAlign='right'>{ getSignSymbol(incomeDiff) } ${Math.abs(incomeDiff)} / year</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+
+      </Table>
+
+      <Table celled color='black'>
+
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell width={3} textAlign='left'><Header as='h4'>Net Total</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>${netCurrent} / year</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>${netFuture} / year</Header></Table.Cell>
+            <Table.Cell width={3} textAlign='right'><Header as='h4'>{ getSignSymbol(netDiff) } ${Math.abs(netDiff)} / year</Header></Table.Cell>
+          </Table.Row>
+        </Table.Body>
+
+      </Table>
+
+      <br/>
+      <br/>
+
+      <ResultsGraph {...props}/>
+    </wrapper>
+  );
+
+};  // End BenefitsTable(<>)
+
+
+export {
+	BenefitsTable
+};

--- a/src/forms/BenefitsTable.js
+++ b/src/forms/BenefitsTable.js
@@ -5,9 +5,14 @@ import {
   Header
 } from 'semantic-ui-react';
 
+// CUSTOM COMPONENTS
 // Both the table and graph should just be added to a results page, but
 // this will do for now
 import ResultsGraph from '../resultsGraph';
+
+// BENEFIT LOGIC
+import { getSNAPBenefits } from '../programs/state/massachusetts/snap';
+import { getHousingBenefit } from '../programs/state/massachusetts/housing';
 
 
 const getSignSymbol = function ( num ) {
@@ -19,21 +24,27 @@ const getSignSymbol = function ( num ) {
 
 const BenefitsTable = function ( props ) {
 
-  var SNAPBenefitCurrent = 100,
-      SNAPBenefitFuture = 90,
-      SNAPDiff = SNAPBenefitCurrent - SNAPBenefitFuture,
-      sec8BenefitCurrent = 90,
-      sec8BenefitFuture = 100,
-      sec8Diff = sec8BenefitCurrent - sec8BenefitFuture,
+  var client        = props.client,
+      currentClient = { ...client };
+  currentClient.futureEarnedIncomeMonthly = currentClient.currentEarnedIncomeMonthly;
+
+  var SNAPBenefitCurrent  = Math.round( getSNAPBenefits( currentClient ).benefitValue * 12 ),
+      SNAPBenefitFuture   = Math.round( getSNAPBenefits( client ).benefitValue * 12 ),
+      SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
+      sec8BenefitCurrent  = Math.round( getHousingBenefit( currentClient ).benefitValue * 12 ),
+      sec8BenefitFuture   = Math.round( getHousingBenefit( client ).benefitValue * 12 ),
+      sec8Diff            = sec8BenefitFuture - sec8BenefitCurrent,
       totalBenefitCurrent = SNAPBenefitCurrent + sec8BenefitCurrent,
-      totalBenefitFuture = SNAPBenefitFuture + sec8BenefitFuture,
-      totalDiff = SNAPDiff + sec8Diff,
-      incomeCurrent = 100,
-      incomeFuture = 200,
-      incomeDiff = incomeCurrent - incomeFuture,
-      netCurrent = totalBenefitCurrent + incomeCurrent,
-      netFuture = totalBenefitFuture + incomeFuture,
-      netDiff = totalDiff + incomeDiff;
+      totalBenefitFuture  = SNAPBenefitFuture + sec8BenefitFuture,
+      totalDiff           = SNAPDiff + sec8Diff,
+      incomeCurrent       = Math.round( client.currentEarnedIncomeMonthly ),
+      incomeFuture        = Math.round( client.futureEarnedIncomeMonthly ),
+      incomeDiff          = incomeFuture - incomeCurrent,
+      netCurrent          = totalBenefitCurrent + incomeCurrent,
+      netFuture           = totalBenefitFuture + incomeFuture,
+      netDiff             = totalDiff + incomeDiff;
+
+console.log(SNAPDiff);
 
   return (
     <wrapper>

--- a/src/visitPage.js
+++ b/src/visitPage.js
@@ -13,7 +13,8 @@ import { clientList } from './clientList';
 // Our Components
 import SimpleMenu from './simpleMenu';
 import AlertSidebar from './alertSidebar'
-import ResultsGraph from './resultsGraph';
+// import ResultsGraph from './resultsGraph';
+import { BenefitsTable } from './forms/BenefitsTable';
 import { CurrentIncomeStep } from './forms/currentIncome';
 import { CurrentExpensesStep } from './forms/currentExpenses';
 import { FutureIncomeStep } from './forms/futureIncome';
@@ -91,7 +92,7 @@ class VisitPage extends Component {
       { title: 'MassHealth', form: HealthStep },      
       // { title: 'SNAP', form: SNAPStep },
       // { title: 'Housing', form: HousingStep },
-      { title: 'Results', form: ResultsGraph }
+      { title: 'Results', form: BenefitsTable }
     ];  // end this.steps {}
   };  // End constructor()
 


### PR DESCRIPTION
It doesn't look identical to the mock-up, but is it close enough to what we're looking for? The separate tables thing is because it was the simplest way to achieve the type of definition it looked like you wanted. We can combine them into one table and see if someone can get into the style manipulation side of things. If someone is into that, let me know and we can explore how to get you/us into that with React. It's just going to take a fair amount of fiddling.

<img width="1365" alt="table-v1" src="https://user-images.githubusercontent.com/4466164/32299249-52daea50-bf2b-11e7-87bb-bbf079488f32.png">
