### PR TITLE
Add 'fuse' files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.fuse_*
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
A fuse file is a linux files for tracking deleted files still in use by a program. Sometimes, when I'm hacking around with the file structure, I get them in the repo. I'd rather not worry about committing them. This PR prevents me from committing them accidentally. This is mostly a personal issue, so feel free to dispute me if you feel like this doesn't belong in the repo.