### PR TITLE
[175] Resolve Key Prop Console Warning on Visit Page

### DIFF
--- a/src/components/StepBar.js
+++ b/src/components/StepBar.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Step } from 'semantic-ui-react';
+
+const StepBar = ({ steps, currentStepIndex, goToStep }) => {
+  steps.forEach((step, index) => {
+    step.completed = index < currentStepIndex
+    step.active = index === (currentStepIndex - 1)
+    step.onClick = (e) => { goToStep(index + 1) }
+    step.key = index
+  })
+
+  return (<Step.Group size='mini' ordered items={steps} />)
+}
+
+export default StepBar

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import {
   Grid,
-  Step,
   Header,
 } from 'semantic-ui-react';
 import {
@@ -25,18 +24,7 @@ import { CurrentExpensesStep } from '../forms/currentExpenses';
 import { FutureIncomeStep } from '../forms/futureIncome';
 import { HouseholdSizeStep } from '../forms/household-size';
 import { CurrentBenefitsStep } from '../forms/current-benefits';
-
-const StepBar = ({ steps, currentStep, goToStep }) => {
-
-  for ( let stepi = 0; stepi < steps.length; stepi++ ) {
-      let step = steps[ stepi ];
-      step.completed = (stepi < currentStep);
-      step.active = (stepi === currentStep - 1);
-      step.onClick = (e) => { goToStep(stepi + 1) } //Create unique click handler for each step
-  }
-
-  return (<Step.Group size='mini' ordered items={steps} />)
-}
+import StepBar from '../components/StepBar'
 
 class VisitPage extends Component {
   constructor(props) {
@@ -191,7 +179,11 @@ class VisitPage extends Component {
           </Grid.Row>
           <Grid.Row>
             <Grid.Column width = {16}>
-              <StepBar currentStep={this.state.currentStep} steps={this.steps} goToStep={this.goToStep} />
+              <StepBar
+                currentStepIndex={this.state.currentStep}
+                steps={this.steps}
+                goToStep={this.goToStep}
+              />
             </Grid.Column>
           </Grid.Row>
           <Grid.Row>
@@ -201,10 +193,12 @@ class VisitPage extends Component {
               </div>
             </Grid.Column>
             <Grid.Column width={4} style={{ height: '100%' }}>
-              <AlertSidebar hasSnap={this.state.client.hasSnap}
-                            hasHousing={this.state.client.hasHousing}
-                            snapAlert={getSNAPBenefits(this.state.client)}
-                            housingAlert={getHousingBenefit(this.state.client)} />
+              <AlertSidebar
+                hasSnap={this.state.client.hasSnap}
+                hasHousing={this.state.client.hasHousing}
+                snapAlert={getSNAPBenefits(this.state.client)}
+                housingAlert={getHousingBenefit(this.state.client)}
+              />
             </Grid.Column>
           </Grid.Row>
         </Grid>


### PR DESCRIPTION
Resolves #175 .

Warning was caused by StepBar not adding a key prop to the step items it passed off to StepBar. Along the way, I split StepBar into its own `components` file, since someone had already gone to the trouble of factoring it as an independent component so nicely. Replaced the c-style loop with a more conventional JS forEach while I was at it.