### PR TITLE
Update Travis' Node Version -> 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 7
+  - 8
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
All the devs are at 8, but we've left poor Travis behind! This PR updates our `travis.yml` file to indicate that it ought to user node version 8 when running our tests.