### PR TITLE
Refactor Header toggle to use Route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,10 +4,6 @@ import {
   Route,
 } from 'react-router-dom'
 
-import {
-  Visibility,
-} from 'semantic-ui-react';
-
 import HomePage from './containers/HomePage'
 import AboutPage from './containers/AboutPage'
 import VisitPage from './containers/VisitPage'
@@ -17,40 +13,19 @@ import Header from './components/Header'
 
 
 // Change HashRouter tags below to Router tags to turn off hash routing; only used to be compatible with GitHub Pages
+const App = () => (
+  <div id='App'>
+    <HashRouter>
+      <div id='HashRouter'>
+        <Route path="/:rest+" component={Header}/>
+        <Route exact path="/" component={HomePage}/>
+        <Route path="/about" component={AboutPage}/>
+        <Route path="/visit/:clientId/:visitId" component={VisitPage}/>
 
-class App extends React.Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      fixHeader: false,
-    }
-  }
-
-  render() {
-    const { fixHeader } = this.state
-
-    return(
-      <div id='App'>
-        <HashRouter>
-          <div id='HashRouter'>
-            <Visibility
-              onTopPassed={ () => { this.setState({fixHeader: true}) } }
-              onTopPassedReverse={ () => { this.setState({fixHeader: false}) } }
-              once={ false }
-            >
-              <Header fix={ fixHeader } />
-            </Visibility>
-
-            <Route exact path="/" component={HomePage}/>
-            <Route path="/about" component={AboutPage}/>
-            <Route path="/visit/:clientId/:visitId" component={VisitPage}/>
-
-          </div>
-        </HashRouter>
-        <Footer />
       </div>
-    )
-  }
-}
+    </HashRouter>
+    <Footer />
+  </div>
+)
 
 export default App;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,33 +1,45 @@
 import React from 'react';
-import {
-  withRouter
-} from 'react-router-dom'
 
 import {
   Segment,
+  Visibility,
 } from 'semantic-ui-react';
 
 import { MainMenu } from '../MainMenu';
 import FixedMenu from '../FixedMenu';
 
-const Header = ({fix, location}) => {
-  if (location.pathname === '/') return (<div></div>)
-  return (
-    <div>
-      <Segment
-        inverted
-        textAlign='center'
-        style={{ padding: '1em 0em' }}
-        vertical
-        color='teal'
+class Header extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      fix: false
+    };
+  }
+
+  render() {
+    const { fix } = this.state;
+
+    return (
+      <Visibility
+        onTopPassed={ () => { this.setState({fix: true}) } }
+        onTopPassedReverse={ () => { this.setState({fix: false}) } }
+        once={ false }
       >
-        { fix ?
-          <FixedMenu /> :
-          <MainMenu/>
-        }
-      </Segment>
-    </div>
-  )
+        <Segment
+          inverted
+          textAlign='center'
+          style={{ padding: '1em 0em' }}
+          vertical
+          color='teal'
+        >
+          { fix ?
+            <FixedMenu /> :
+            <MainMenu />
+          }
+        </Segment>
+      </Visibility>
+    );
+  }
 }
 
-export default withRouter(Header);
+export default Header;


### PR DESCRIPTION
Use React Router to match path when determining whether to show the `<Header>` component. Also moves the `<Header>` related state into the `<Header>` component rather than maintain it in `<App>`. Less re-rendering that way.

Hi. Was looking into Code for Boston and some of the code y'all have written, and thought I'd do something useful while I was here... and steal @knod's issue~

Closes #239.