### PR TITLE
Some more design changes

### DIFF
--- a/src/BetaWarning.js
+++ b/src/BetaWarning.js
@@ -1,10 +1,15 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
+import { Menu, Responsive } from 'semantic-ui-react';
 
 const BetaWarning = function ( props ) {
   return (
     <Menu.Item>
-      <div><strong>This tool is a prototype and should not be used to make financial decisions.</strong></div>
+      <Responsive as='strong' {...Responsive.onlyTablet}>
+        This tool is a prototype.
+      </Responsive>
+      <Responsive as='strong' {...Responsive.onlyComputer}>
+        This tool is a prototype and should not be used to make financial decisions.
+      </Responsive>
     </Menu.Item>
   );
 };  // End BetaWarning(<>)

--- a/src/ResultsGraph.js
+++ b/src/ResultsGraph.js
@@ -141,7 +141,7 @@ const ResultsGraph = (props) => {
 
   // Non-saving version for first prototype testing
   return (
-    <wrapper className = 'result-page'>
+    <wrapper className = 'result-page flex-item flex-column'>
       <FormPartsContainer
         title     = {'Results'}
         left      = {{ name: 'Go Back', func: props.previousStep }}

--- a/src/components/StepBar.js
+++ b/src/components/StepBar.js
@@ -9,7 +9,7 @@ const StepBar = ({ steps, currentStepIndex, goToStep }) => {
     step.key = index
   })
 
-  return (<Step.Group size='mini' ordered items={steps} />)
+  return (<Step.Group className='six' size='mini' ordered items={steps} />)
 }
 
 export default StepBar

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -51,8 +51,8 @@ class VisitPage extends Component {
     this.steps = [
       { title: 'Current Benefits', form: CurrentBenefitsStep, },
       { title: 'Household', form: HouseholdStep },
-      { title: 'Current Income', form: CurrentIncomeStep },
-      { title: 'Current Expenses', form: CurrentExpensesStep },
+      { title: 'Income', form: CurrentIncomeStep },
+      { title: 'Expenses', form: CurrentExpensesStep },
       { title: 'Predictions', form: PredictionsStep },
       { title: 'Results', form: ResultsGraph }
     ];  // end this.steps {}

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import {
-  Grid,
+  Container,
+  Responsive
 } from 'semantic-ui-react';
 import {
   Redirect,
@@ -125,7 +126,7 @@ class VisitPage extends Component {
   render() {
 
     return (
-      <div className='forms-container'>
+      <div className='forms-container flex-item flex-column'>
         <Prompt
           when={this.state.isBlocking}
           message='Are you sure you want to leave the page with unsaved changes?'
@@ -136,35 +137,22 @@ class VisitPage extends Component {
           false
         }
 
-        <Grid
-          style={{ height: '100%', padding: '2em 0' }}
-          verticalAlign='middle'
-          container
+        {/* `padding` here duplicates previous `<Grid>` styleing */}
+        <Container
+          className='flex-item flex-column'
+          style={{ padding: '42px 0' }}
         >
-          <Grid.Row>
-            <Grid.Column width={10}>
-
-            </Grid.Column>
-            <Grid.Column floated='right' width={6}>
-            </Grid.Column>
-          </Grid.Row>
-          <Grid.Row only='computer'>
-            <Grid.Column width = {16}>
-              <StepBar
-                currentStepIndex={this.state.currentStep}
-                steps={this.steps}
-                goToStep={this.goToStep}
-              />
-            </Grid.Column>
-          </Grid.Row>
-          <Grid.Row>
-            <Grid.Column width={12}>
-              <div>
-                {this.getCurrentStep()}
-              </div>
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
+          <Responsive minWidth='874.5' style={{ padding: '14px 0' }}>
+            <StepBar
+              currentStepIndex={this.state.currentStep}
+              steps={this.steps}
+              goToStep={this.goToStep}
+            />
+          </Responsive>
+          <div className="flex-item flex-column" style={{ padding: '14px 0' }}>
+            {this.getCurrentStep()}
+          </div>
+        </Container>
       </div>
     )
   }

--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -202,7 +202,7 @@ const MemberField = function ({ household, time, setHousehold, setClientProperty
 
   // The font size thing is a bit weird, but... later
   return (
-    <Form.Field key={indx}>
+    <Form.Field className='flex-item' key={indx}>
 
       <Columns.One>
         { indx > 0
@@ -350,7 +350,7 @@ const HouseholdStep = function ( props ) {
   const setTimeProp = getTimeSetter( 'current', props.changeClient );
 
   return (
-    <Form className='current-household-size-form'>
+    <Form className='current-household-size-form flex-column flex-item'>
       <FormPartsContainer
         title     = {'Household'}
         clarifier = {'Information about the members of your household.'}

--- a/src/forms/Predictions.js
+++ b/src/forms/Predictions.js
@@ -67,7 +67,7 @@ const PredictionsStep = function ( props ) {
 
   /** @todo Are these titles accurate now? */
   return (
-    <Form className = 'income-form'>
+    <Form className = 'income-form flex-item flex-column'>
       <FormPartsContainer
         title     = 'Future Household Income'
         clarifier = 'How much money would your household make in the future?'

--- a/src/forms/current-benefits.js
+++ b/src/forms/current-benefits.js
@@ -55,7 +55,7 @@ const CurrentBenefitsStep = (props) => {
   const setTimeProp = getTimeSetter( 'current', props.changeClient );
 
   return (
-    <Form size='massive' className='household-size-form'>
+    <Form size='massive' className='household-size-form flex-item flex-column'>
       <FormPartsContainer
         title     = {'Current Benefits'}
         clarifier = {'Select the benefits you currently receive.'}

--- a/src/forms/currentExpenses.js
+++ b/src/forms/currentExpenses.js
@@ -389,7 +389,7 @@ const CurrentExpensesStep = function ( props ) {
   const setTimeProp = getTimeSetter( 'current', props.changeClient );
 
   return (
-    <Form className = 'expense-form'>
+    <Form className = 'expense-form flex-item flex-column'>
       <FormPartsContainer
         title     = {'Current Household Expenses'}
         clarifier = {null}

--- a/src/forms/currentIncome.js
+++ b/src/forms/currentIncome.js
@@ -102,7 +102,7 @@ const CurrentIncomeStep = function ( props ) {
 
   /** @todo Are these titles accurate now? */
   return (
-    <Form className = 'income-form'>
+    <Form className = 'income-form flex-item flex-column'>
       <FormPartsContainer
         title     = 'Current Household Income'
         clarifier = 'Income that you collected in the past 12 months.'

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -128,8 +128,8 @@ const BottomButtons = function({ left, right }) {
 */
 const FormPartsContainer = function(props) {
   return (
-    <Segment padded='very' style={{ minHeight: '600px' }}>
-      <Segment style={{ minHeight: '500px' }} basic={true}>
+    <Segment padded='very' className="flex-item flex-column">
+      <Segment basic={true} className="flex-item">
         <Header as='h1' color='teal' textAlign='center'>
           { props.title }
         </Header>

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@ form .field-aligner {
 }
 
 #App {
-  height: 100%;
+  min-height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -23,23 +23,37 @@ form .field-aligner {
 
 #HashRouter {
   flex: 1 0;
+  display: flex;
+  flex-direction: column;
 }
 
 #HomePage {
   background-image: url(./images/splash.svg) !important;
   background-size: cover !important;
+  flex: 1 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100%;
 }
 
 #HomeContent {
-  /*display: inline-block;*/
-  display: flex;,
-  justify-content: space-between;
+  flex: 1 0;
+  display: flex;
+  justify-content: center;
   flex-direction: column;
+}
+
+/*
+Used to fill vertical space.
+`height: 100%` doesn't work with Flexbox on Mobile Safari.
+*/
+.flex-column {
+  display: flex!important;
+  flex-direction: column;
+}
+.flex-item {
+  flex: 1 0;
 }
 
 .center-contents {

--- a/src/index.css
+++ b/src/index.css
@@ -5,9 +5,8 @@ body {
 }
 
 form .field-aligner {
-    display: inline-block;
-    text-align: left;
-    max-width: 80%;
+  display: inline-block;
+  text-align: left;
 }
 
 #App {

--- a/src/test/forms/__snapshots__/Predictions.test.js.snap
+++ b/src/test/forms/__snapshots__/Predictions.test.js.snap
@@ -3,24 +3,14 @@
 exports[`Prediction component renders as snapshot correctly 1`] = `
 <form
   action={undefined}
-  className="ui form income-form"
+  className="ui form income-form flex-item flex-column"
   onSubmit={[Function]}
 >
   <div
-    className="ui very padded segment"
-    style={
-      Object {
-        "minHeight": "600px",
-      }
-    }
+    className="ui very padded segment flex-item flex-column"
   >
     <div
-      className="ui basic segment"
-      style={
-        Object {
-          "minHeight": "500px",
-        }
-      }
+      className="ui basic segment flex-item"
     >
       <h1
         className="ui teal center aligned header"


### PR DESCRIPTION
Took a bit of tinkering and backtracking to get something that works, so I ended up with one big commit. I can go back and split things up, but I wanted to run the changes by y'all first.

% heights don't play well with Flexbox on Mobile Safari. So once Flexbox starts being used, its nothing but Flexbox. So much Flexbox.

Removed the min-heights on `<FormPartsContainer>`. Safari didn't like those either. Instead I just grew the container so that its bottom was more or less flush with the footer.

Shortened some of the step text. 'Current Income' => 'Income'

The steps and forms now take up the full width of the container.

The beta warning is shortened on tablets to 'This tool is a prototype'.

see #134