### PR TITLE
Addresses #281, Fix benefits table summary

### DIFF
--- a/src/forms/BenefitsTable.js
+++ b/src/forms/BenefitsTable.js
@@ -34,8 +34,8 @@ const BenefitsTable = function ( props ) {
 
 
 
-  var SNAPBenefitCurrent  = Math.round( getSNAPBenefits( currentClient ).benefitValue * 12 ),
-      SNAPBenefitFuture   = Math.round( getSNAPBenefits( futureClient ).benefitValue * 12 ),
+  var SNAPBenefitCurrent  = currentClient.current.hasSnap ? Math.round( getSNAPBenefits( currentClient ).benefitValue * 12 ) : 0,
+      SNAPBenefitFuture   = futureClient.future.hasSnap ? Math.round( getSNAPBenefits( futureClient ).benefitValue * 12 ) : 0,
       SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
       sec8BenefitCurrent  = Math.round( getHousingBenefit( currentClient ).benefitValue * 12 ),
       sec8BenefitFuture   = Math.round( getHousingBenefit( futureClient ).benefitValue * 12 ),

--- a/src/test/forms/__snapshots__/BenefitsTable.test.js.snap
+++ b/src/test/forms/__snapshots__/BenefitsTable.test.js.snap
@@ -152,7 +152,7 @@ exports[`Benefits table renders correctly 1`] = `
           }
         >
           $
-          2304
+          0
            / year
         </td>
         <td
@@ -167,7 +167,7 @@ exports[`Benefits table renders correctly 1`] = `
           }
         >
           $
-          2304
+          0
            / year
         </td>
         <td

--- a/src/test/forms/__snapshots__/Predictions.test.js.snap
+++ b/src/test/forms/__snapshots__/Predictions.test.js.snap
@@ -330,7 +330,7 @@ exports[`Prediction component renders as snapshot correctly 1`] = `
                   }
                 >
                   $
-                  2304
+                  0
                    / year
                 </td>
                 <td
@@ -345,7 +345,7 @@ exports[`Prediction component renders as snapshot correctly 1`] = `
                   }
                 >
                   $
-                  2304
+                  0
                    / year
                 </td>
                 <td


### PR DESCRIPTION
SNAP was always being awarded, whether it was selected or not.

Feels like I'm propagating hacky code here, but the table now reads as its supposed to.

Closes #281