### PR TITLE
Less timeframe hacking, #263

### DIFF
--- a/src/ResultsGraph.js
+++ b/src/ResultsGraph.js
@@ -16,7 +16,7 @@ const ResultsGraph = (props) => {
 
   var snapData = xRange.map(annualIncome => {
       fakeClient.future.earned = annualIncome/12;
-      return getSNAPBenefits(fakeClient).benefitValue * 12});
+      return getSNAPBenefits(fakeClient, 'future').benefitValue * 12});
 
   /** Section-8 Housing Choice Voucher */
   /** @todo Base this rent on FMR areas and client area of residence if no rent available. */

--- a/src/forms/BenefitsTable.js
+++ b/src/forms/BenefitsTable.js
@@ -34,8 +34,8 @@ const BenefitsTable = function ( props ) {
 
 
 
-  var SNAPBenefitCurrent  = currentClient.current.hasSnap ? Math.round( getSNAPBenefits( currentClient ).benefitValue * 12 ) : 0,
-      SNAPBenefitFuture   = futureClient.future.hasSnap ? Math.round( getSNAPBenefits( futureClient ).benefitValue * 12 ) : 0,
+  var SNAPBenefitCurrent  = currentClient.current.hasSnap ? Math.round( getSNAPBenefits( props.client, 'current' ).benefitValue * 12 ) : 0,
+      SNAPBenefitFuture   = futureClient.future.hasSnap ? Math.round( getSNAPBenefits( props.client, 'future' ).benefitValue * 12 ) : 0,
       SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
       sec8BenefitCurrent  = Math.round( getHousingBenefit( currentClient ).benefitValue * 12 ),
       sec8BenefitFuture   = Math.round( getHousingBenefit( futureClient ).benefitValue * 12 ),

--- a/src/utils/cashflow.js
+++ b/src/utils/cashflow.js
@@ -64,8 +64,12 @@ const getGrossUnearnedIncomeMonthly = function ( client, timeframe ) {
 * income with no deductions or exclusions.
 */
 const getSimpleGrossIncomeMonthly = function ( client, timeframe ) {
-  var earned    = client[ timeframe ].earned,
-      unearned  = getGrossUnearnedIncomeMonthly( client, timeframe );
+  // Temporary measure till converted to just passing already timeframe'd object
+  var timeClient = client;
+  if ( typeof timeframe === 'string' ) { timeClient = client[ timeframe ]; }
+  // Real logic
+  var earned    = timeClient.earned,
+      unearned  = getGrossUnearnedIncomeMonthly( timeClient, timeframe );
 	return earned + unearned;
 };  // End getSimpleGrossIncomeMonthly()
 
@@ -104,7 +108,11 @@ const sumCashflow = function ( client, timeframe, props ) {
 * @returns Component
 */
 const toCashflow = function ( client, timeframe, prop ) {
-  return client[ timeframe ][ prop ] || 0;
+  // Temporary measure till converted to just passing already timeframe'd object
+  var timeClient = client;
+  if ( typeof timeframe === 'string' ) { timeClient = client[ timeframe ]; }
+  // Real logic
+  return timeClient[ prop ] || 0;
 };  // End toCashflow()
 
 

--- a/src/utils/getMembers.js
+++ b/src/utils/getMembers.js
@@ -31,7 +31,11 @@ const getEveryMember = function ( memberList, memberTest ) {
 *     'current' or 'future', that pass `memberTest()`
 */
 const getEveryMemberOfHousehold = function ( client, timeframe, memberTest ) {
-  var household = client[ timeframe ].household;
+  // Temporary measure till converted to just passing already timeframe'd object
+  var timeClient = client;
+  if ( typeof timeframe === 'string' ) { timeClient = client[ timeframe ]; }
+  // Real logic
+  var household = timeClient.household;
   return getEveryMember( household, memberTest );
 };  // End getEveryMemberOfHousehold()
 


### PR DESCRIPTION
Section 8 is going to need the whole `client` object, and I'd rather the function signature for benefit calculations be the same, so we'll never be able to pass in just the `current` or `future` client, but we can get closer to that. Something that's a bit less fragile.

Next is to convert 'housing.js', then to clean up the temporary measures. Just want a fresh eye on the basic premise.