### PR TITLE
Award housing benefits only if selected

### DIFF
--- a/src/forms/BenefitsTable.js
+++ b/src/forms/BenefitsTable.js
@@ -34,11 +34,11 @@ const BenefitsTable = function ( props ) {
 
 
 
-  var SNAPBenefitCurrent  = currentClient.current.hasSnap ? Math.round( getSNAPBenefits( props.client, 'current' ).benefitValue * 12 ) : 0,
-      SNAPBenefitFuture   = futureClient.future.hasSnap ? Math.round( getSNAPBenefits( props.client, 'future' ).benefitValue * 12 ) : 0,
+  var SNAPBenefitCurrent  = props.client.current.hasSnap ? Math.round( getSNAPBenefits( props.client, 'current' ).benefitValue * 12 ) : 0,
+      SNAPBenefitFuture   = props.client.future.hasSnap ? Math.round( getSNAPBenefits( props.client, 'future' ).benefitValue * 12 ) : 0,
       SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
-      sec8BenefitCurrent  = Math.round( getHousingBenefit( currentClient ).benefitValue * 12 ),
-      sec8BenefitFuture   = Math.round( getHousingBenefit( futureClient ).benefitValue * 12 ),
+      sec8BenefitCurrent  = currentClient.future.hasHousing ? Math.round( getHousingBenefit( currentClient ).benefitValue * 12 ) : 0,
+      sec8BenefitFuture   = futureClient.future.hasHousing ? Math.round( getHousingBenefit( futureClient ).benefitValue * 12 ) : 0,
       sec8Diff            = sec8BenefitFuture - sec8BenefitCurrent,
       totalBenefitCurrent = SNAPBenefitCurrent + sec8BenefitCurrent,
       totalBenefitFuture  = SNAPBenefitFuture + sec8BenefitFuture,


### PR DESCRIPTION
Added more conditionals to `<BenefitsTable>` calculations. Should probably be done in `getSNAPBenefits()` and `getHousing()`, but I wasn't sure about the result object being returned. The extra fields don't seem to be used. Can I just remove them?

Closes #281 