### PR TITLE
Removes duplicate code for default client, makes variant clearer

### DIFF
--- a/src/test/programs/federal/snap.test.js
+++ b/src/test/programs/federal/snap.test.js
@@ -1,8 +1,18 @@
 import { getSNAPBenefits } from '../../../programs/federal/snap';
 
+// CLIENTS
+import { CLIENT_DEFAULTS } from '../../../utils/CLIENT_DEFAULTS';
+import { cloneDeep } from 'lodash';
 
-const defaultClient = {"current":{"hasSnap":false,"hasHousing":false,"household":[{"m_age":30,"m_role":"head","m_disabled":false}],"earned":0,"TAFDC":0,"SSI":0,"SSDI":0,"childSupportIn":0,"unemployment":0,"workersComp":0,"pension":0,"socialSecurity":0,"alimony":0,"otherIncome":0,"incomeExclusions":0,"childDirectCare":0,"childBeforeAndAfterSchoolCare":0,"childTransportation":0,"childOtherCare":0,"earnedBecauseOfChildCare":0,"childSupportPaidOut":0,"adultDirectCare":0,"adultTransportation":0,"adultOtherCare":0,"disabledAssistance":0,"earnedBecauseOfAdultCare":0,"disabledMedical":0,"otherMedical":0,"shelter":"homeless","contractRent":0,"rentShare":0,"rent":0,"mortgage":0,"housingInsurance":0,"propertyTax":0,"climateControl":false,"nonHeatElectricity":false,"phone":false,"fuelAssistance":false,"otherExpenses":0},"future":{"hasSnap":false,"hasHousing":false,"household":[{"m_age":30,"m_role":"head","m_disabled":false}],"earned":0,"TAFDC":0,"SSI":0,"SSDI":0,"childSupportIn":0,"unemployment":0,"workersComp":0,"pension":0,"socialSecurity":0,"alimony":0,"otherIncome":0,"incomeExclusions":0,"childDirectCare":0,"childBeforeAndAfterSchoolCare":0,"childTransportation":0,"childOtherCare":0,"earnedBecauseOfChildCare":0,"childSupportPaidOut":0,"adultDirectCare":0,"adultTransportation":0,"adultOtherCare":0,"disabledAssistance":0,"earnedBecauseOfAdultCare":0,"disabledMedical":0,"otherMedical":0,"shelter":"homeless","contractRent":0,"rentShare":0,"rent":0,"mortgage":0,"housingInsurance":0,"propertyTax":0,"climateControl":false,"nonHeatElectricity":false,"phone":false,"fuelAssistance":false,"otherExpenses":0}};
-const client1 = {"current":{"hasSnap":true,"hasHousing":false,"household":[{"m_age":30,"m_role":"head","m_disabled":false,"index":0},{"m_age":30,"m_role":"spouse","m_disabled":false,"index":1},{"m_age":"12","m_role":"member","m_disabled":false,"index":2}],"earned":2165,"TAFDC":0,"SSI":0,"SSDI":0,"childSupportIn":0,"unemployment":0,"workersComp":0,"pension":0,"socialSecurity":0,"alimony":0,"otherIncome":0,"incomeExclusions":0,"childDirectCare":0,"childBeforeAndAfterSchoolCare":0,"childTransportation":0,"childOtherCare":0,"earnedBecauseOfChildCare":0,"childSupportPaidOut":0,"adultDirectCare":0,"adultTransportation":0,"adultOtherCare":0,"disabledAssistance":0,"earnedBecauseOfAdultCare":0,"disabledMedical":0,"otherMedical":0,"shelter":"renter","contractRent":0,"rentShare":0,"rent":600,"mortgage":0,"housingInsurance":0,"propertyTax":0,"climateControl":false,"nonHeatElectricity":false,"phone":false,"fuelAssistance":false,"otherExpenses":0},"future":{"hasSnap":true,"hasHousing":false,"household":[{"m_age":30,"m_role":"head","m_disabled":false,"index":0},{"m_age":30,"m_role":"spouse","m_disabled":false,"index":1},{"m_age":"12","m_role":"member","m_disabled":false,"index":2}],"earned":2165,"TAFDC":0,"SSI":0,"SSDI":0,"childSupportIn":0,"unemployment":0,"workersComp":0,"pension":0,"socialSecurity":0,"alimony":0,"otherIncome":0,"incomeExclusions":0,"childDirectCare":0,"childBeforeAndAfterSchoolCare":0,"childTransportation":0,"childOtherCare":0,"earnedBecauseOfChildCare":0,"childSupportPaidOut":0,"adultDirectCare":0,"adultTransportation":0,"adultOtherCare":0,"disabledAssistance":0,"earnedBecauseOfAdultCare":0,"disabledMedical":0,"otherMedical":0,"shelter":"renter","contractRent":0,"rentShare":0,"rent":600,"mortgage":0,"housingInsurance":0,"propertyTax":0,"climateControl":false,"nonHeatElectricity":false,"phone":false,"fuelAssistance":false,"otherExpenses":0}};
+const defaultClient = cloneDeep( CLIENT_DEFAULTS );
+const variant1            = cloneDeep( CLIENT_DEFAULTS );
+variant1.current.hasSnap  = true;
+variant1.current.household.push( {"m_age":30,"m_role":"spouse","m_disabled":false} );
+variant1.current.household.push( {"m_age":12,"m_role":"member","m_disabled":false} );
+variant1.current.earned   = 2165;
+variant1.current.shelter  = "renter";
+variant1.current.rent     = 600;
+variant1.future           = cloneDeep( variant1.current );
 
 describe('getSNAPBenefits', () => {
   describe('default client', () => {
@@ -14,13 +24,13 @@ describe('getSNAPBenefits', () => {
       expect(getSNAPBenefits(defaultClient, 'future')).toEqual(192);
     });
   });
-  describe('client 1', () => {
+  describe('variant 1', () => {
     it('Should calculate the correct current benefits', () => {
-      expect(getSNAPBenefits(client1, 'current')).toBeCloseTo(32.4, 4);
+      expect(getSNAPBenefits(variant1, 'current')).toBeCloseTo(32.4, 4);
     });
     
     it('Should calculate the correct future benefits', () => {
-      expect(getSNAPBenefits(client1, 'future')).toBeCloseTo(32.4, 4);
+      expect(getSNAPBenefits(variant1, 'future')).toBeCloseTo(32.4, 4);
     });
   });
 });

--- a/src/test/programs/federal/snap.test.js
+++ b/src/test/programs/federal/snap.test.js
@@ -7,7 +7,7 @@ import { cloneDeep } from 'lodash';
 const defaultClient       = cloneDeep( CLIENT_DEFAULTS );
 const variant1            = cloneDeep( CLIENT_DEFAULTS );
 variant1.current.hasSnap  = true;
-variant1.current.household.push( {"m_age":30,"m_role":"head","m_disabled":false} );
+// Head of household member is already there
 variant1.current.household.push( {"m_age":30,"m_role":"spouse","m_disabled":false} );
 variant1.current.household.push( {"m_age":12,"m_role":"member","m_disabled":false} );
 variant1.current.earned   = 2165;

--- a/src/test/programs/federal/snap.test.js
+++ b/src/test/programs/federal/snap.test.js
@@ -13,6 +13,8 @@ variant1.current.household.push( {"m_age":12,"m_role":"member","m_disabled":fals
 variant1.current.earned   = 2165;
 variant1.current.shelter  = "renter";
 variant1.current.rent     = 600;
+// SNAP never needs to test future
+// Housing only changes earned income in future
 variant1.future           = cloneDeep( variant1.current );
 
 describe('getSNAPBenefits', () => {

--- a/src/test/programs/federal/snap.test.js
+++ b/src/test/programs/federal/snap.test.js
@@ -4,9 +4,10 @@ import { getSNAPBenefits } from '../../../programs/federal/snap';
 import { CLIENT_DEFAULTS } from '../../../utils/CLIENT_DEFAULTS';
 import { cloneDeep } from 'lodash';
 
-const defaultClient = cloneDeep( CLIENT_DEFAULTS );
+const defaultClient       = cloneDeep( CLIENT_DEFAULTS );
 const variant1            = cloneDeep( CLIENT_DEFAULTS );
 variant1.current.hasSnap  = true;
+variant1.current.household.push( {"m_age":30,"m_role":"head","m_disabled":false} );
 variant1.current.household.push( {"m_age":30,"m_role":"spouse","m_disabled":false} );
 variant1.current.household.push( {"m_age":12,"m_role":"member","m_disabled":false} );
 variant1.current.earned   = 2165;


### PR DESCRIPTION
Shows more clearly what properties are different between the
default client and the variant.

@todo Change client value setting function so that it can be used
to set client values, perhaps. May do a better job of causing
errors when values are set incorrectly.

Addresses #315