### PR TITLE
Fixes #341, fixes #342, disabled/elderly wrong on expenses page

### DIFF
--- a/src/forms/CurrentExpenses.js
+++ b/src/forms/CurrentExpenses.js
@@ -265,7 +265,7 @@ const ExpensesFormContent = function ({ client, current, time, setClientProperty
     return isDisabled( member ) || member.m_age >= 60;
   };
   var elderlyOrDisabled = getEveryMember( household, isElderlyOrDisabled ),
-      elderlyOrDisabledHeadAndSpouse = getEveryMember( elderlyOrDisabled, isHeadOrSpouse );
+      elderlyOrDisabledHeadOrSpouse = getEveryMember( elderlyOrDisabled, isHeadOrSpouse );
 
   /**
   * @todo Does money from any programs count as income?
@@ -328,12 +328,12 @@ const ExpensesFormContent = function ({ client, current, time, setClientProperty
         : null
       }
 
-        {/* These medical expenses don't count for Section 8 unless
-          the disabled person is the head or spouse. From 
-          http://www.tacinc.org/media/58886/S8MS%20Full%20Book.pdf 
-          Appendix B, item (D) */}
-        { elderlyOrDisabledHeadAndSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0)
-          ? <wrapper>
+      {/* These medical expenses don't count for Section 8 unless
+        the disabled person is the head or spouse. From 
+        http://www.tacinc.org/media/58886/S8MS%20Full%20Book.pdf 
+        Appendix B, item (D) */}
+      { elderlyOrDisabledHeadOrSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0)
+        ? <wrapper>
           <FormHeading>Unreimbursed Medical Expenses</FormHeading>
           <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
           <ul>
@@ -348,8 +348,8 @@ const ExpensesFormContent = function ({ client, current, time, setClientProperty
             <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred).</li>
           </ul>
           <IntervalColumnHeadings type={type}/>
-          <CashFlowRow {...sharedProps} generic='disabledOrElderlyMedical'> Disabled/Elderly medical expenses </CashFlowRow>
-          <CashFlowRow {...sharedProps} generic='membersMedical'> Medical expenses of other members </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic='disabledMedical'> Disabled/Elderly medical expenses </CashFlowRow>
+          <CashFlowRow {...sharedProps} generic='otherMedical'> Medical expenses of other members </CashFlowRow>
         </wrapper>
         : null
       }

--- a/src/utils/getMembers.js
+++ b/src/utils/getMembers.js
@@ -85,7 +85,7 @@ const getDependentsOfHousehold = function ( client ) {
 // --- DISABLED --- \\
 
 const isDisabled = function ( member ) {
-  return member.m_disable;
+  return member.m_disabled;
 };  // End isDisabled()
 
 


### PR DESCRIPTION
Problem was two-fold. Typo in 'getMembers.js' and wrong prop names on expenses page.

Lines 331 - 336 is a whitespace change. Sorry about that.