### PR TITLE
Fixes #389 - Form Scroll Up

### DIFF
--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -147,8 +147,8 @@ class VisitPage extends Component {
   }
 
   scrollToTop = () => {
-    document.body.scrollTop = 0;
-    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE, and Opera
   };
 
   nextStep = () => {

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -146,16 +146,23 @@ class VisitPage extends Component {
     }
   }
 
+  scrollToTop = () => {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  };
+
   nextStep = () => {
     this.setState(prevState => ({
       currentStep: prevState.currentStep + 1
     }));
+    this.scrollToTop();
   };
 
   previousStep = () => {
     this.setState(prevState => ({
       currentStep: prevState.currentStep - 1
     }));
+    this.scrollToTop();
   };
 
   goToStep = (index) => {


### PR DESCRIPTION
Hello, here is my simple fix for the issue where users become disoriented when clicking 'Next' or 'Previous' on the app's forms by showing a new or previous form from the top of the page.