### PR TITLE
Consolidate program and income values on predictions page (Issue #404)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3995,7 +3995,7 @@
     "fsevents": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "optional": true,
       "requires": {
         "nan": "2.8.0",
@@ -9530,7 +9530,7 @@
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         }
       }
     },

--- a/src/forms/Predictions.js
+++ b/src/forms/Predictions.js
@@ -7,7 +7,7 @@ import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formH
 import { BenefitsTable } from './BenefitsTable';
 
 // COMPONENT HELPER FUNCTIONS
-import { getTimeSetter } from '../utils/getTimeSetter';
+import { getTimeSetter, getBenefitTimeFrames, getIncomeTimeFrames } from '../utils/getTimeSetter';
 import { getSNAPBenefits } from '../programs/federal/snap';
 import { getHousingBenefit } from '../programs/massachusetts/housing';
 import {
@@ -35,7 +35,7 @@ const IncomeForm = function ({ future, time, setClientProperty }) {
 
   var type = 'income';
 
-  /** 
+  /**
   * As per Project Hope input, for the first prototype we're only
   * including the ability to change earned income.
   */
@@ -44,10 +44,10 @@ const IncomeForm = function ({ future, time, setClientProperty }) {
       <IntervalColumnHeadings type={type}/>
       <CashFlowRow
           timeState={future}
-				  type={type} 
+				  type={type}
 				  time={time}
 				  setClientProperty={setClientProperty}
-				  generic='earned' 
+				  generic='earned'
 				  labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
           Earned income
       </CashFlowRow>
@@ -71,12 +71,10 @@ const Chart = function({ client }) {
 
   var curr = client.current;
 
-  var SNAPBenefitCurrent  = curr.hasSnap ? Math.round( getSNAPBenefits( client, 'current' ) * 12 ) : 0,
-      SNAPBenefitFuture   = curr.hasSnap ? Math.round( getSNAPBenefits( client, 'future' ) * 12 ) : 0,
-      sec8BenefitCurrent  = curr.hasHousing ? Math.round( getHousingBenefit( client, 'current' ) * 12 ) : 0,
-      sec8BenefitFuture   = curr.hasHousing ? Math.round( getHousingBenefit( client, 'future' ) * 12 ) : 0,
-      incomeCurrent       = Math.round( curr.earned * 12 ),
-      incomeFuture        = Math.round( client.future.earned * 12 );
+  var
+    { benefitCurrent: SNAPBenefitCurrent, benefitFuture: SNAPBenefitFuture } = getBenefitTimeFrames( client, 'hasSnap', getSNAPBenefits ),
+    { benefitCurrent: sec8BenefitCurrent, benefitFuture: sec8BenefitFuture } = getBenefitTimeFrames( client, 'hasHousing', getHousingBenefit ),
+    { incomeCurrent, incomeFuture } = getIncomeTimeFrames( client );
 
   var snapData    = [ SNAPBenefitCurrent, SNAPBenefitFuture ],
       housingData = [ sec8BenefitCurrent, sec8BenefitFuture ],

--- a/src/utils/getTimeSetter.js
+++ b/src/utils/getTimeSetter.js
@@ -17,5 +17,22 @@ const getTimeSetter = function ( time, func ) {
 
 };  // End getTimeSetter()
 
+const getBenefitTimeFrames = function ( client, benefitCheck, benefitsFunc ) {
+    if (client.current[benefitCheck]) {
+        return {
+            benefitCurrent: Math.round( benefitsFunc ( client, 'current' ) * 12 ),
+            benefitFuture: Math.round( benefitsFunc ( client, 'future' ) * 12 )
+        }
+    } else {
+        return 0;
+    }
+};
 
-export { getTimeSetter };
+const getIncomeTimeFrames = function( client ) {
+    return {
+        incomeCurrent: Math.round( client.current.earned * 12 ),
+        incomeFuture: Math.round( client.future.earned * 12 )
+    }
+};
+
+export { getTimeSetter, getBenefitTimeFrames, getIncomeTimeFrames };


### PR DESCRIPTION
Wasn't sure if the best place to refactor this was in the 'getTimeSetter.js' helper file in the utils directory but it seemed related.