### PR TITLE
Fixes #429, voucher rent expenses language

### DIFF
--- a/src/forms/rentFields.js
+++ b/src/forms/rentFields.js
@@ -125,7 +125,7 @@ class RentShareField extends Component {
           contractRent = {baseContractRent * 12}
         />
         <div className={'cashflow-column cashflow-column-last-child'}>
-          <label>Rent Share</label>
+          <label>How much of that rent do you pay out of your pocket?</label>
         </div>
         {error &&
           <Label basic color='red' pointing="left">
@@ -206,7 +206,7 @@ class ContractRentField extends Component {
           rentShare = {baseRentShare * 12}
         />
         <div className={'cashflow-column cashflow-column-last-child'}>
-          <label>Contract Rent</label>
+          <label>What is the full listed price of this housing unit? (Without utilities)</label>
           <InlineLabelInfo>
             The full amount the landlord would charge without a Section 8 voucher
           </InlineLabelInfo>

--- a/src/forms/rentFields.js
+++ b/src/forms/rentFields.js
@@ -125,7 +125,7 @@ class RentShareField extends Component {
           contractRent = {baseContractRent * 12}
         />
         <div className={'cashflow-column cashflow-column-last-child'}>
-          <label>How much of that rent do you pay out of your pocket?</label>
+          <label>Your Rent Share (how much of the total rent you have to pay)</label>
         </div>
         {error &&
           <Label basic color='red' pointing="left">
@@ -206,7 +206,7 @@ class ContractRentField extends Component {
           rentShare = {baseRentShare * 12}
         />
         <div className={'cashflow-column cashflow-column-last-child'}>
-          <label>What is the full listed price of this housing unit? (Without utilities)</label>
+          <label>Contract Rent (the total rent for your apartment)</label>
           <InlineLabelInfo>
             The full amount the landlord would charge without a Section 8 voucher
           </InlineLabelInfo>


### PR DESCRIPTION
During the beta tests, I saw people filling out the 'Contract Rent' for vouchers, but not the 'Rent Share'. Later, several expressed that they weren't sure what the difference was between the two. We'd made the assumption that that language was familiar to them, but it's not. We need to ask these questions in a different way.

Just need thoughts on the wording.