### PR TITLE
Fix errors when editing age field

### DIFF
--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -221,12 +221,13 @@ const MemberField = function ({ household, time, setHousehold, setClientProperty
 
       <Columns.Three>
         <ManagedNumberField
-          value     = {member.m_age}
-          name      = {'m_age'}
-          className = {time + ' member-age ' + time}
-          validate  = {isPositiveWholeNumber}
-          format    = {function ( value ) { return value; }}
-          store     = {onMemberChange} />
+          value      = {member.m_age}
+          name       = {'m_age'}
+          className  = {time + ' member-age ' + time}
+          validation = {isPositiveWholeNumber}
+          format     = {function ( value ) { return value; }}
+          store      = {onMemberChange}
+          onBlur     = {function () { return true; }} />
       </Columns.Three>
 
       <Columns.Four>


### PR DESCRIPTION
Fixes errors that were occurring when editing the household age fields, due to nonexistence of the "validation" and "onBlur" props of the special ManagedNumberField used in that form. I believe this is just a change that should've occurred in #433 but got overlooked.