### PR TITLE
Fix blocked navigation when forms untouched

### DIFF
--- a/src/components/ReactRouterConfirmLeave.js
+++ b/src/components/ReactRouterConfirmLeave.js
@@ -10,6 +10,7 @@ import * as getUserConfirmation from '../utils/getUserConfirmation';
  * @param props {object}
  * @param props.prompt {function}
  * @param props.message {string} - Passed on to <OnLeavePrompt>
+ * @param props.isBlocking {boolean} - Whether the prompt should be shown
  * 
  * @see OnLeavePrompt
  * @see getUserConfirmation
@@ -26,7 +27,8 @@ class ReactRouterConfirmLeave extends React.Component {
   }
 
   render() {
-    return <Prompt {...this.props} />;
+    const { isBlocking, ...rest } = this.props;
+    return <Prompt when={isBlocking} {...rest} />;
   }
 }
 

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -234,6 +234,7 @@ class VisitPage extends Component {
         <ReactRouterConfirmLeave
           message='default'
           prompt={this.prompt}
+          isBlocking={this.state.isBlocking}
         />
         <ErrorPrompt
           callback={ok => ok && this.resetClient()}


### PR DESCRIPTION
During the recent refactor of the various prompts, the React Router `<Prompt>` was no longer passed the `when` prop, and so was not aware when the prompt should and should not be shown. This caused navigation attempts handled by React Router to always be blocked before the form had been interacted with.

The solution was to once again provide the `when` prop; this value is called `isBlocking` in `<VisitPage>`.

Closes #473