### PR TITLE
Make ManagedNumberField.handleFocus set 'focused' and 'focusedVal' correctly

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -400,14 +400,18 @@ const IntervalColumnHeadings = function ({ type }) {
 class ManagedNumberField extends Component {
   constructor ( props ) {
     super( props );
-    this.state = { valid: true, focused: false, focusedVal: this.props.value, };
+    var { format, value } = props;
+    this.state = { valid: true, focused: false, focusedVal: format( value ) };
   }  // End constructor()
 
   //change form to blank string after click, before input
   handleFocus = ( evnt, inputProps ) => {
     // This makes sure that only zeroes and blanks get reset
+    var { format, value } = this.props;
     if (!Number.parseFloat(evnt.target.value)) {
       this.setState({ focused: true, focusedVal: "" });
+    } else {
+      this.setState({ focused: true, focusedVal: format( value ) });
     }
   }
 
@@ -542,7 +546,7 @@ const MonthlyCashFlowRow = function ({ inputProps, baseValue, setClientProperty,
 
 
 /** Yes/no toggleable radio button group with a label
- * 
+ *
  * @function
  * @param {object} props
  * @property {string} props.labelText


### PR DESCRIPTION
Fixes #475. The main problem was that handleFocus wasn't setting "focused" to true if the value was nonzero, so it would only show the rounded value even if the user invisibly enters a number with more than 2 decimal places.  In addition, the function wasn't setting "focusedVal" to the value on focus, which is especially important if switching from one box to another on the same row.