### PR TITLE
Treat empty string in ManagedNumberField like a 0

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -425,7 +425,11 @@ class ManagedNumberField extends Component {
     var { value } = inputProps,
           valid   = validation( value );
 
-    if ( valid ) { store( evnt, inputProps, otherData ); }
+    if ( valid ) {
+      store( evnt, inputProps, otherData );
+    } else if ( value.length === 0 ) {  // treat empty string as 0
+      store( evnt, { ...inputProps, value: '0' }, otherData );
+    }
     this.setState({ focusedVal: value, valid: valid });
   }  // End handleChange()
 


### PR DESCRIPTION
Fixes #425 by making the ManagedNumberField report a value of '0' to the  `store` function when the field is really blank.