### PR TITLE
Removes jsdocs linting until that package is more consistent. Issue #507

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
       "object-curly-spacing": ["warn", "always"],	
       "array-bracket-spacing": ["warn", "always"],
       "computed-property-spacing": ["warn", "always"],
-      "valid-jsdoc": "warn",
       "react/self-closing-comp": "warn",
       "comma-dangle": ["warn", "always-multiline"],
       "space-infix-ops": "warn",


### PR DESCRIPTION
Currently it doesn't always understand the difference between
a class description and the description of a method of the class.
It's more complex than that, but I think it's not something we
need to battle right now.