### PR TITLE
Makes changes for lint msgs issue #507 - snap.js

### DIFF
--- a/src/programs/federal/snap.js
+++ b/src/programs/federal/snap.js
@@ -70,7 +70,9 @@ hlp.hasDisabledOrElderlyMember = function (client) {
 };
 
 hlp.hasDependentsOver12 = function (client) {
-  var isOver12 = function (member) { return !isUnder13(member); };
+  var isOver12 = function (member) { 
+    return !isUnder13(member); 
+  };
   var members = getEveryMember(getDependentsOfHousehold(client), isOver12);
   return members.length > 0;
 };
@@ -242,8 +244,12 @@ hlp.getHousingDeduction = function(client) {
 };
 
 hlp.getHomelessDeduction = function(client) {
-  if (hlp.isHomeless(client)) { return SNAPData.HOMELESS_DEDUCTION; }
-  else { return 0; }
+  if (hlp.isHomeless(client)) { 
+    return SNAPData.HOMELESS_DEDUCTION; 
+  }
+  else { 
+    return 0; 
+  }
 };
 
 


### PR DESCRIPTION
The line I changed from { return 0;} to put into two lines did not cause a lint error.  I changed as it seems it should have.