### PR TITLE
Reorganize snippets into subobjects for each page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ class App extends Component {
                 return (
                   <Header
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets } />);
               } } />
             <Route
               exact
@@ -51,7 +51,7 @@ class App extends Component {
                 return (
                   <HomePage
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets.HomePage } />);
               } } />
             <Route
               path="/about"
@@ -59,7 +59,7 @@ class App extends Component {
                 return (
                   <AboutPage
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets } />);
               } } />
             <Route
               path="/visit/:clientId/:visitId"
@@ -67,7 +67,7 @@ class App extends Component {
                 return (
                   <VisitPage
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets } />);
               } } />
             <Route
               path="/visit/load"
@@ -75,7 +75,7 @@ class App extends Component {
                 return (
                   <VisitPage
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets } />);
               } } />
             <Route
               path="/load"
@@ -83,11 +83,11 @@ class App extends Component {
                 return (
                   <VisitPage
                     { ...props }
-                    snippets={ snippets } />); 
+                    snippets={ snippets } />);
               } } />
           </div>
         </HashRouter>
-        <Footer snippets={ snippets } />
+        <Footer snippets={ snippets.Footer } />
       </div>
     );
   }

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -71,7 +71,26 @@ class VisitPage extends Component {
     };  // end this.state {}
 
     this.steps = [
-      { title: 'Current Benefits', form: CurrentBenefitsStep }, { title: 'Household', form: HouseholdStep }, { title: 'Income', form: CurrentIncomeStep }, { title: 'Expenses', form: CurrentExpensesStep }, { title: 'Predictions', form: PredictionsStep },//,
+      {
+        title: 'Current Benefits',
+        form:  CurrentBenefitsStep,
+      },
+      {
+        title: 'Household',
+        form:  HouseholdStep,
+      },
+      {
+        title: 'Income',
+        form:  CurrentIncomeStep,
+      },
+      {
+        title: 'Expenses',
+        form:  CurrentExpensesStep,
+      },
+      {
+        title: 'Predictions',
+        form:  PredictionsStep,
+      },//,
     //  { title: 'Graphs', form: ResultsGraph }
     ];  // end this.steps {}
 
@@ -218,6 +237,7 @@ class VisitPage extends Component {
   getCurrentStep = () => {
     var step = Math.max(1, Math.min(this.steps.length, this.state.currentStep)) - 1;   //keep it between 1 and 8 and convert to 0 index
     var FormSection = this.steps[ step ].form;
+    var formSnippets = this.state.snippets[ this.steps[ step ].title ];
 
     return (
       <div>
@@ -233,7 +253,7 @@ class VisitPage extends Component {
           saveForm={ this.saveForm }
           resetClient={ this.resetClientPrompt }
           feedbackPrompt={ this.feedbackPrompt }
-          snippets={ this.state.snippets } />
+          snippets={ formSnippets } />
         <FeedbackAnytime feedbackPrompt={ this.feedbackPrompt } />
         <ResetAnytime resetClient={ this.resetClientPrompt } />
       </div>

--- a/src/localization/all.js
+++ b/src/localization/all.js
@@ -1,9 +1,13 @@
 /** Contains and exports all the languages */
 
+import DE from './de';
 import EN from './en';
 import ZH from './zh';
-import DE from './de';
 
-var localizations = { en: EN, zh: ZH, de: DE };
+var localizations = {
+  de: DE,
+  en: EN,
+  zh: ZH,
+};
 
 export { localizations };

--- a/src/localization/de.js
+++ b/src/localization/de.js
@@ -2,6 +2,7 @@ export default {
 
   'langName': 'Deutsch',
   'langCode': 'de',
+
   'HomePage': {
     'appName':          'Cliff Effects Werkzeug',
     'prototypeNote':    'Ein Prototyp für Beratungshilfe*',
@@ -9,63 +10,69 @@ export default {
     'toFirstInputPage': 'Beginnen',
     'toAboutPage':      'Mehr lernen',
   },
+
   'Footer': {
     'header':         'Cliff Effects Tool',
     'cfbCreditIntro': 'Mit ',
     'cfbCredit':      ' von Code for Boston gemacht',
   },
-  'hasSection8': {
-    'label': 'Haben Sie Section 8 Housing?',
-    'hint':  'Section 8 gibt Hilfe für die Miete',
+
+  'Current Benefits': {
+    'hasSection8': {
+      'label': 'Haben Sie Section 8 Housing?',
+      'hint':  'Section 8 gibt Hilfe für die Miete',
+    },
+    'hasSnap': {
+      'label': 'Haben Sie SNAP?',
+      'hint':  'SNAP gibt Hilfe für das Essenkaufen',
+    },
   },
-  'hasSnap': {
-    'label': 'Haben Sie SNAP?',
-    'hint':  'SNAP gibt Hilfe für das Essenkaufen',
+
+  'Income': {
+    'earnedIncome': {
+      'label': 'Einkommen von der Arbeit',
+      'hint':  'Einkommen von der Arbeit',
+    },
+    'TAFDC': {
+      'label': 'TAFDC',
+      'hint':  'TAFDC (Transitional Aid to Families with Dependent Children) ist ein Programm von dem Bundesstaat Massachusetts, das Familien mit Kindern während einer kurzen Zeit hilft',
+    },
+    'SSI': {
+      'label': 'SSI',
+      'hint':  'SSI (Supplemental Security Income) ist ein Programm von der amerikanischen Bundesregierung, das finanzielle und medizinische Hilfe den Leuten gibt, die blind, behindert oder älter als 65 Jahre sind',
+    },
+    'SSDI': {
+      'label': 'SSDI',
+      'hint':  'SSDI (Social Security Disability Income) ist ein Program von der amerikanischen Bundesregierung, das behinderten Leuten hilft',
+    },
+    'childSupport': {
+      'label': 'Bekommene Kinderunterstützung',
+      'hint':  'Kinderunterstützung ist Geld, das Ihr(e) ehemalige(r) Herr/Frau Ihnen gibt, um Ihre Kinder zu unterstützen',
+    },
+    'unemployment': {
+      'label': 'Arbeitslosenunterstützung',
+      'hint':  'Arbeitslosenunterstützung hilft Leuten, die ihre Arbeit verloren haben',
+    },
+    'workersComp': {
+      'label': 'Arbeitsunfallversicherung',
+      'hint':  'Arbeitsunfallversicherung hilft Leuten, die einen Unfall bei der Arbeit haben',
+    },
+    'pension': {
+      'label': 'Rente',
+      'hint':  'Eine Rente gibt Einkommen einer Person, die sich aus Altersgründen aus der Karriere zurückzieht',
+    },
+    'socialSecurity': {
+      'label': 'Staatliche Rentenversicherung',
+      'hint':  'Staatliche Rentenversicherung ist ein Program von der amerikanischen Bundesregierung, das den Rentnern hilft',
+    },
+    'alimony': {
+      'label': 'Unterhaltszahlung',
+      'hint':  'Unterhaltszahlung ist Geld, das eine Person der zweiten Person nach einer Ehescheidung bezahlt',
+    },
+    'otherIncome': {
+      'label': 'Anderes Einkommen',
+      'hint':  'Bitte bemerken Sie hier irgendwelches Einkommen aus anderen Quellen, die nicht schon bemerkt werden',
+    },
   },
-  'earnedIncome': {
-    'label': 'Einkommen von der Arbeit',
-    'hint':  'Einkommen von der Arbeit',
-  },
-  'TAFDC': {
-    'label': 'TAFDC',
-    'hint':  'TAFDC (Transitional Aid to Families with Dependent Children) ist ein Programm von dem Bundesstaat Massachusetts, das Familien mit Kindern während einer kurzen Zeit hilft',
-  },
-  'SSI': {
-    'label': 'SSI',
-    'hint':  'SSI (Supplemental Security Income) ist ein Programm von der amerikanischen Bundesregierung, das finanzielle und medizinische Hilfe den Leuten gibt, die blind, behindert oder älter als 65 Jahre sind',
-  },
-  'SSDI': {
-    'label': 'SSDI',
-    'hint':  'SSDI (Social Security Disability Income) ist ein Program von der amerikanischen Bundesregierung, das behinderten Leuten hilft',
-  },
-  'childSupport': {
-    'label': 'Bekommene Kinderunterstützung',
-    'hint':  'Kinderunterstützung ist Geld, das Ihr(e) ehemalige(r) Herr/Frau Ihnen gibt, um Ihre Kinder zu unterstützen',
-  },
-  'unemployment': {
-    'label': 'Arbeitslosenunterstützung',
-    'hint':  'Arbeitslosenunterstützung hilft Leuten, die ihre Arbeit verloren haben',
-  },
-  'workersComp': {
-    'label': 'Arbeitsunfallversicherung',
-    'hint':  'Arbeitsunfallversicherung hilft Leuten, die einen Unfall bei der Arbeit haben',
-  },
-  'pension': {
-    'label': 'Rente',
-    'hint':  'Eine Rente gibt Einkommen einer Person, die sich aus Altersgründen aus der Karriere zurückzieht',
-  },
-  'socialSecurity': {
-    'label': 'Staatliche Rentenversicherung',
-    'hint':  'Staatliche Rentenversicherung ist ein Program von der amerikanischen Bundesregierung, das den Rentnern hilft',
-  },
-  'alimony': {
-    'label': 'Unterhaltszahlung',
-    'hint':  'Unterhaltszahlung ist Geld, das eine Person der zweiten Person nach einer Ehescheidung bezahlt',
-  },
-  'otherIncome': {
-    'label': 'Anderes Einkommen',
-    'hint':  'Bitte bemerken Sie hier irgendwelches Einkommen aus anderen Quellen, die nicht schon bemerkt werden',
-  },
-  
 };
-  
+

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -2,6 +2,7 @@ export default {
 
   'langName': 'English',
   'langCode': 'en',
+
   'HomePage': {
     'appName':          'Cliff Effects Tool',
     'prototypeNote':    'GUIDANCE PROTOYPE*',
@@ -9,62 +10,74 @@ export default {
     'toFirstInputPage': 'Get Started',
     'toAboutPage':      'Learn More',
   },
+
   'Footer': {
     'header':         'Cliff Effects Tool',
     'cfbCreditIntro': 'Made with ',
     'cfbCredit':      ' by Code for Boston',
   },
-  'hasSection8': {
-    'label': 'Do you have Section 8 Housing?',
-    'hint':  'Section 8 provides rental housing assistance.',
-  },
-  'hasSnap': {
-    'label': 'Do you have SNAP?',
-    'hint':  'SNAP provides assistance with buying food',
-  },
-  'earnedIncome': {
-    'label': 'Earned income',
-    'hint':  'Earned income is how much you and your family get paid from working',
-  },
-  'TAFDC': {
-    'label': 'TAFDC',
-    'hint':  'Transitional Aid to Families with Dependent Children provides short-term financial assistance to families with children',
-  },
-  'SSI': {
-    'label': 'SSI',
-    'hint':  'Supplemental Security Income is a federal program that provides financial and health care assistance to people 65 and over, or people who are blind or disabled',
-  },
-  'SSDI': {
-    'label': 'SSDI',
-    'hint':  'Social Security Disability Income is a federal program to help people with disabilities',
-  },
-  'childSupport': {
-    'label': 'Child support recieved',
-    'hint':  'Child support is money paid to you by a former spouse to help your child',
-  },
-  'unemployment': {
-    'label': 'Unemployment',
-    'hint':  'Unemployment benefits provide income to people who have been laid off',
-  },
-  'workersComp': {
-    'label': 'Worker\'s compensation',
-    'hint':  'Worker\'s Compensation provides assistance for people who have been injured on the job',
-  },
-  'pension': {
-    'label': 'Pension',
-    'hint':  'A pension provides income to retirees, usually from their former employers',
-  },
-  'socialSecurity': {
-    'label': 'Social security',
-    'hint':  'Social Security is a federal program that provides assistance to retirees',
-  },
-  'alimony': {
-    'label': 'Alimony',
-    'hint':  'Alimony is money paid by one spouse to the other after a divorce',
-  },
-  'otherIncome': {
-    'label': 'Other income',
-    'hint':  'Please note income you may have from sources that are not listed above',
+
+  'Current Benefits': {
+    'hasSection8': {
+      'label': 'Do you have Section 8 Housing?',
+      'hint':  'Section 8 provides rental housing assistance.',
+    },
+    'hasSnap': {
+      'label': 'Do you have SNAP?',
+      'hint':  'SNAP provides assistance with buying food',
+    },
   },
 
+  'Household': {},
+
+  'Income': {
+    'earnedIncome': {
+      'label': 'Earned income',
+      'hint':  'Earned income is how much you and your family get paid from working',
+    },
+    'TAFDC': {
+      'label': 'TAFDC',
+      'hint':  'Transitional Aid to Families with Dependent Children provides short-term financial assistance to families with children',
+    },
+    'SSI': {
+      'label': 'SSI',
+      'hint':  'Supplemental Security Income is a federal program that provides financial and health care assistance to people 65 and over, or people who are blind or disabled',
+    },
+    'SSDI': {
+      'label': 'SSDI',
+      'hint':  'Social Security Disability Income is a federal program to help people with disabilities',
+    },
+    'childSupport': {
+      'label': 'Child support recieved',
+      'hint':  'Child support is money paid to you by a former spouse to help your child',
+    },
+    'unemployment': {
+      'label': 'Unemployment',
+      'hint':  'Unemployment benefits provide income to people who have been laid off',
+    },
+    'workersComp': {
+      'label': 'Worker\'s compensation',
+      'hint':  'Worker\'s Compensation provides assistance for people who have been injured on the job',
+    },
+    'pension': {
+      'label': 'Pension',
+      'hint':  'A pension provides income to retirees, usually from their former employers',
+    },
+    'socialSecurity': {
+      'label': 'Social security',
+      'hint':  'Social Security is a federal program that provides assistance to retirees',
+    },
+    'alimony': {
+      'label': 'Alimony',
+      'hint':  'Alimony is money paid by one spouse to the other after a divorce',
+    },
+    'otherIncome': {
+      'label': 'Other income',
+      'hint':  'Please note income you may have from sources that are not listed above',
+    },
+  },
+
+  'Expenses': {},
+
+  'Predictions': {},
 };

--- a/src/localization/zh.js
+++ b/src/localization/zh.js
@@ -1,58 +1,63 @@
 export default {
 
-  'langName':    '中文',
-  'langCode':    'zh',
-  'hasSection8': {
-    'label': '您是否擁有 Section 8 住房補貼？',
-    'hint':  'Section 8 爲租房提供補貼。',
-  },
-  'hasSnap': {
-    'label': '您是否擁有糧食券 (SNAP)?',
-    'hint':  '糧食券(SNAP)爲購買食品提供補貼',
-  },
-  'hasEarnedIncome': {
-    'label': '您是否擁有工資收入？',
-    'hint':  '工資收入是指來自工資或者自僱的收入',
-  },
-  'hasTAFDC': {
-    'label': '您是否擁有向有受撫養兒童的家庭發放的過渡性援助 (TAFDC)？',
-    'hint':  '向有受撫養兒童的家庭發放的過渡性援助 (TAFDC) 是爲有受撫楊兒童的家庭提供的短期經濟援助',
-  },
-  'hasSSI': {
-    'label': '您是否擁有附加保障收入 (SSI)？',
-    'hint':  '附加保障收入是聯邦政府爲65週歲及以上的老人，以及任何年齡的失明或殘障認識提供的財政和健保補助',
-  },
-  'hasSSDI': {
-    'label': '您是否擁有社會保障殘疾保險金 (SSDI)？',
-    'hint':  '社會安全殘疾保險金 (SSDI) 是一項聯邦政府爲殘障人士提供幫助的項目',
-  },
-  'hasChildSupport': {
-    'label': '您是否擁有子女撫養費？',
-    'hint':  '子女撫養費是你的前任配偶爲你們的小孩所提供的經濟援助',
-  },
-  'hasUnemployment': {
-    'label': '您是否擁有失業救濟？',
-    'hint':  '失業救濟爲已經下崗的人羣提供收入',
-  },
-  'hasWorkersComp': {
-    'label': '您是否擁有勞工災害補償？',
-    'hint':  '勞工災害補償爲在工作中受傷的人提供補助',
-  },
-  'hasPension': {
-    'label': '您是否擁有養老金？',
-    'hint':  '養老金主爲已退休的僱員提供的收入，通常由前任僱主提供',
-  },
-  'hasSocialSecurity': {
-    'label': '您是否擁有社會保障收入?',
-    'hint':  '社會保障是聯邦政府爲已退休人士提供的福利',
-  },
-  'hasAlimony': {
-    'label': '您是否擁有贍養費？',
-    'hint':  '贍養費是離婚後夫妻一方向另一方提供的經濟資助',
-  },
-  'hasOtherIncome': {
-    'label': '您是否擁有其他收入？',
-    'hint':  '請列出你所擁有的但爲在上方列出的收入',
+  'langName': '中文',
+  'langCode': 'zh',
+
+  'Current Benefits': {
+    'hasSection8': {
+      'label': '您是否擁有 Section 8 住房補貼？',
+      'hint':  'Section 8 爲租房提供補貼。',
+    },
+    'hasSnap': {
+      'label': '您是否擁有糧食券 (SNAP)?',
+      'hint':  '糧食券(SNAP)爲購買食品提供補貼',
+    },
   },
 
+  'Income': {
+    'hasEarnedIncome': {
+      'label': '您是否擁有工資收入？',
+      'hint':  '工資收入是指來自工資或者自僱的收入',
+    },
+    'hasTAFDC': {
+      'label': '您是否擁有向有受撫養兒童的家庭發放的過渡性援助 (TAFDC)？',
+      'hint':  '向有受撫養兒童的家庭發放的過渡性援助 (TAFDC) 是爲有受撫楊兒童的家庭提供的短期經濟援助',
+    },
+    'hasSSI': {
+      'label': '您是否擁有附加保障收入 (SSI)？',
+      'hint':  '附加保障收入是聯邦政府爲65週歲及以上的老人，以及任何年齡的失明或殘障認識提供的財政和健保補助',
+    },
+    'hasSSDI': {
+      'label': '您是否擁有社會保障殘疾保險金 (SSDI)？',
+      'hint':  '社會安全殘疾保險金 (SSDI) 是一項聯邦政府爲殘障人士提供幫助的項目',
+    },
+    'hasChildSupport': {
+      'label': '您是否擁有子女撫養費？',
+      'hint':  '子女撫養費是你的前任配偶爲你們的小孩所提供的經濟援助',
+    },
+    'hasUnemployment': {
+      'label': '您是否擁有失業救濟？',
+      'hint':  '失業救濟爲已經下崗的人羣提供收入',
+    },
+    'hasWorkersComp': {
+      'label': '您是否擁有勞工災害補償？',
+      'hint':  '勞工災害補償爲在工作中受傷的人提供補助',
+    },
+    'hasPension': {
+      'label': '您是否擁有養老金？',
+      'hint':  '養老金主爲已退休的僱員提供的收入，通常由前任僱主提供',
+    },
+    'hasSocialSecurity': {
+      'label': '您是否擁有社會保障收入?',
+      'hint':  '社會保障是聯邦政府爲已退休人士提供的福利',
+    },
+    'hasAlimony': {
+      'label': '您是否擁有贍養費？',
+      'hint':  '贍養費是離婚後夫妻一方向另一方提供的經濟資助',
+    },
+    'hasOtherIncome': {
+      'label': '您是否擁有其他收入？',
+      'hint':  '請列出你所擁有的但爲在上方列出的收入',
+    },
+  },
 };


### PR DESCRIPTION
As a first step to #513, this reorganizes `en.js` and the other language files somewhat so that each step is in its own nested object. The key matches the step title as specified by `VisitPage.js`, and this is used to pass only the snippets that are needed to each step (and likewise for HomePage and Footer). I also alphabetized the languages and made a couple aesthetic changes.