### PR TITLE
Unit tests for ManagedNumberField for handleFocus and handleBlur

### DIFF
--- a/src/test/forms/__snapshots__/formHelpers.test.js.snap
+++ b/src/test/forms/__snapshots__/formHelpers.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManagedNumberField should match snapshot 1`] = `
+<FormInput
+  as={[Function]}
+  control={[Function]}
+  error={false}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  type="number"
+/>
+`;

--- a/src/test/forms/formHelpers.test.js
+++ b/src/test/forms/formHelpers.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ManagedNumberField } from '../../forms/formHelpers';
+
+test('ManagedNumberField should match snapshot', () => {
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ jest.fn() }
+      value={ 0 } />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
+test('should set focused state to true on focus', () => {
+  const value = 10;
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ jest.fn() }
+      value={ value } />
+  );
+  wrapper.find('FormInput').simulate('focus', { target: { value }}, undefined);
+  expect(wrapper.state('focused')).toBe(true);
+});
+
+test('should blank focusedVal state before focus if current value of FormInput is 0', () => {
+  const inputValue = 0;
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ jest.fn() }
+      value={ 0 } />
+  );
+  wrapper.find('FormInput').simulate('focus', { target: { value: inputValue }}, undefined);
+  expect(wrapper.state('focusedVal')).toBe('');
+});
+
+test('should set focused state to false on blur', () => {
+  const value = 10;
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ jest.fn() }
+      onBlur={ jest.fn() }
+      value={ value } />
+  );
+  wrapper.setState({ focused: true });
+  wrapper.find('FormInput').simulate('blur', {});
+  expect(wrapper.state('focused')).toBe(false);
+});

--- a/src/test/forms/formHelpers.test.js
+++ b/src/test/forms/formHelpers.test.js
@@ -6,20 +6,31 @@ import { ManagedNumberField } from '../../forms/formHelpers';
 test('ManagedNumberField should match snapshot', () => {
   const wrapper = shallow(
     <ManagedNumberField
-      format={ jest.fn() }
+      format={ () => {} }
       value={ 0 } />
   );
   expect(wrapper).toMatchSnapshot();
 });
 
-test('should set focused state to true on focus', () => {
+test('should set focused state to true on focus if current value of FormInput is positive number', () => {
   const value = 10;
   const wrapper = shallow(
     <ManagedNumberField
-      format={ jest.fn() }
+      format={ () => {} }
       value={ value } />
   );
-  wrapper.find('FormInput').simulate('focus', { target: { value }}, undefined);
+  wrapper.find('FormInput').simulate('focus', { target: { value }});
+  expect(wrapper.state('focused')).toBe(true);
+});
+
+test('should set focused state to true on focus if current value of FormInput is 0', () => {
+  const value = 0;
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ () => {} }
+      value={ value } />
+  );
+  wrapper.find('FormInput').simulate('focus', { target: { value }});
   expect(wrapper.state('focused')).toBe(true);
 });
 
@@ -27,10 +38,10 @@ test('should blank focusedVal state before focus if current value of FormInput i
   const inputValue = 0;
   const wrapper = shallow(
     <ManagedNumberField
-      format={ jest.fn() }
+      format={ () => {} }
       value={ 0 } />
   );
-  wrapper.find('FormInput').simulate('focus', { target: { value: inputValue }}, undefined);
+  wrapper.find('FormInput').simulate('focus', { target: { value: inputValue }});
   expect(wrapper.state('focusedVal')).toBe('');
 });
 
@@ -38,8 +49,8 @@ test('should set focused state to false on blur', () => {
   const value = 10;
   const wrapper = shallow(
     <ManagedNumberField
-      format={ jest.fn() }
-      onBlur={ jest.fn() }
+      format={ () => {} }
+      onBlur={ () => {} }
       value={ value } />
   );
   wrapper.setState({ focused: true });


### PR DESCRIPTION
I wrote a few unit tests for ManagedNumberField -- is this along the lines of what you were looking for? If yes, then I'll continue writing other tests based on the Google Doc.

Specifically, this PR implements the tests requested in the Google Doc:
- handleFocus: should blank the component before focus, should set focused in state to true
- handleBlur: should set state to focused: false

I also added a snapshot test to make sure ManagedNumberField was rendering as expected.