### PR TITLE
ManagedNumberField: Adds unit tests for onChange and for setting error state of FormInput; addresses #586

### DIFF
--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -57,3 +57,97 @@ test('should set focused state to false on blur', () => {
   wrapper.find('FormInput').simulate('blur', {});
   expect(wrapper.state('focused')).toBe(false);
 });
+
+test('should change local and app state correctly when user inputs positive number', () => {
+  const mockValidation = jest.fn();
+  const mockStore = jest.fn();
+
+  // Define the test case here
+  const userInput = 5;
+  mockValidation.mockReturnValue(true);
+
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ () => {} }
+      otherData={ null }
+      store={ mockStore }
+      validation={ mockValidation }
+      value={ 0 } />
+  );
+  wrapper.find('FormInput').simulate('change', {}, { value: userInput });
+
+  // sending the proper call to change the application's state
+  // TODO: Determine whether the 1st and 3rd arguments should be checked w/ Enzyme too
+  expect(mockStore.mock.calls[ 0 ][ 1 ]).toEqual({ value: userInput });
+
+  // changes to this.state's focusedVal and valid variables
+  expect(wrapper.state('focusedVal')).toBe(userInput);
+  expect(wrapper.state('valid')).toBe(true);
+});
+
+test('should change local and app state correctly when user inputs empty string', () => {
+  const mockValidation = jest.fn();
+  const mockStore = jest.fn();
+
+  // Define the test case here
+  const userInput = '';
+  mockValidation.mockReturnValue(false);
+
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ () => {} }
+      otherData={ null }
+      store={ mockStore }
+      validation={ mockValidation }
+      value={ 0 } />
+  );
+  wrapper.find('FormInput').simulate('change', {}, { value: userInput });
+
+  // sending the proper call to change the application's state
+  // Since userInput is empty string, store should be given 0 as value
+  expect(mockStore.mock.calls[ 0 ][ 1 ]).toEqual({ value: '0' });
+
+  // changes to this.state's focusedVal and valid variables
+  expect(wrapper.state('focusedVal')).toBe(userInput);
+  expect(wrapper.state('valid')).toBe(false);
+});
+
+test('should change local and app state correctly when user inputs negative number', () => {
+  const mockValidation = jest.fn();
+  const mockStore = jest.fn();
+
+  // Define the test case here
+  const userInput = -6;
+  mockValidation.mockReturnValue(false);
+
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ () => {} }
+      otherData={ null }
+      store={ mockStore }
+      validation={ mockValidation }
+      value={ 0 } />
+  );
+  wrapper.find('FormInput').simulate('change', {}, { value: userInput });
+
+  // expect that the store has not been called
+  expect(mockStore).not.toHaveBeenCalled();
+
+  // changes to this.state's focusedVal and valid variables
+  expect(wrapper.state('focusedVal')).toBe(userInput);
+  expect(wrapper.state('valid')).toBe(false);
+});
+
+test('should set FormInput error state properly when valid condition changes', () => {
+  const wrapper = shallow(
+    <ManagedNumberField
+      format={ () => {} }
+      value={ 0 } />
+  );
+  // Set valid to false -- FormInput error should be true
+  wrapper.setState({ valid: false });
+  expect(wrapper.find('FormInput').props().error).toBe(true);
+  // Set valid back to true -- FormInput error should be false
+  wrapper.setState({ valid: true });
+  expect(wrapper.find('FormInput').props().error).toBe(false);
+});


### PR DESCRIPTION
Most of the new tests here make sure that when onChange is called, the handleChange function properly sets local state, and calls or doesn't call the store if appropriate. (These tests do not check to see that validation() yields the proper result, nor does it test that the store actually updates, as those unit tests would be done on different components than this one.)

One of the tests ensures that when the local state's "valid" variable changes, the FormInput's error prop has the correct value. (The actual setting of an error className is presumably done within the semantic-ui-react code and therefore is not tested here.)