### PR TITLE
ManagedNumberField cleaning up variable name and function call

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -487,12 +487,6 @@ class ManagedNumberField extends Component {
   };
 
   handleBlur = (evnt) => {
-<<<<<<< HEAD
-=======
-    this.props.onBlur(evnt);
-
-    // Set local state for blur
->>>>>>> dev
     this.setState({ focused: false, valid: true });
   };
 
@@ -598,7 +592,6 @@ const CashFlowRow = function ({ generic, timeState, setClientProperty, children 
         displayValidator: hasOnlyNonNegNumberChars,
         storeValidator:   isNonNegNumber,
         format:           toMoneyStr,
-        onBlur:           function () { return true; },
       };
 
   return (

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -490,8 +490,6 @@ class ManagedNumberField extends Component {
   };
 
   handleChange = (evnt, inputProps) => {
-    console.log('evnt: ', evnt);
-    console.log('inputProps: ', inputProps);
     var { validation, store, otherData } = this.props;
     var { value } = inputProps,
         valid   = validation(value);

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -475,7 +475,7 @@ class ManagedNumberField extends Component {
   }  // End constructor()
 
   //change form to blank string after click, before input
-  handleFocus = (evnt, inputProps) => {
+  handleFocus = (evnt) => {
     // This makes sure that only zeroes and blanks get reset
     var { format, value } = this.props;
     if (!Number.parseFloat(evnt.target.value)) {
@@ -491,6 +491,8 @@ class ManagedNumberField extends Component {
   };
 
   handleChange = (evnt, inputProps) => {
+    console.log('evnt: ', evnt);
+    console.log('inputProps: ', inputProps);
     var { validation, store, otherData } = this.props;
     var { value } = inputProps,
         valid   = validation(value);

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -486,7 +486,6 @@ class ManagedNumberField extends Component {
   };
 
   handleBlur = (evnt) => {
-    this.props.onBlur(evnt);
     this.setState({ focused: false, valid: true });
   };
 

--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -50,7 +50,6 @@ test('should set focused state to false on blur', () => {
   const wrapper = shallow(
     <ManagedNumberField
       format={ () => {} }
-      onBlur={ () => {} }
       value={ value } />
   );
   wrapper.setState({ focused: true });

--- a/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
+++ b/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
@@ -11,7 +11,6 @@ exports[`CashFlowRow should match snapshot 1`] = `
     displayValidator={[Function]}
     format={[Function]}
     name="name"
-    onBlur={[Function]}
     otherData={
       Object {
         "interval": "weekly",
@@ -26,7 +25,6 @@ exports[`CashFlowRow should match snapshot 1`] = `
     displayValidator={[Function]}
     format={[Function]}
     name="name"
-    onBlur={[Function]}
     otherData={
       Object {
         "interval": "monthly",
@@ -41,7 +39,6 @@ exports[`CashFlowRow should match snapshot 1`] = `
     displayValidator={[Function]}
     format={[Function]}
     name="name"
-    onBlur={[Function]}
     otherData={
       Object {
         "interval": "yearly",


### PR DESCRIPTION
When I was writing unit tests, I noticed a couple of seemingly redundant/unnecessary bits of code in the ManagedNumberField.

The handleBlur function appeared to first call this.props.onBlur -- which would be calling itself, right? Removing the call didn't seem to affect app functionality. When I made this change, I also cleaned up a line of code in the test that's no longer needed if this change is made.

handleFocus takes in inputProps but doesn't use it, so I suggest removing the parameter.