### PR TITLE
ManagedNumberField bug fix - restores previous input after invalid entry

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -487,6 +487,13 @@ class ManagedNumberField extends Component {
 
   handleBlur = (evnt) => {
     this.props.onBlur(evnt);
+    // If field is empty string, set value to be 0 so that a user can clear the field
+    var { store, otherData } = this.props;
+    var value = evnt.target.value;
+    if (value.length === 0) {
+      store(evnt, { value: '0' }, otherData);
+    }
+    // Set local state for blur
     this.setState({ focused: false, valid: true });
   };
 
@@ -497,8 +504,6 @@ class ManagedNumberField extends Component {
 
     if (valid) {
       store(evnt, inputProps, otherData);
-    } else if (value.length === 0) {  // treat empty string as 0
-      store(evnt, { ...inputProps, value: '0' }, otherData);
     }
     this.setState({ focusedVal: value, valid: valid });
   };  // End handleChange()

--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -54,6 +54,6 @@ test('should set focused state to false on blur', () => {
       value={ value } />
   );
   wrapper.setState({ focused: true });
-  wrapper.find('FormInput').simulate('blur', {});
+  wrapper.find('FormInput').simulate('blur', { target: { value }});
   expect(wrapper.state('focused')).toBe(false);
 });


### PR DESCRIPTION
Per Slack channel discussion from today. Also updates a test that would break now that handleBlur sometimes needs the value from evnt.target.

Functionality Q:
Does the 2nd argument of store() require anything from inputProps other than value? I couldn't figure out how to pass inputProps into handleBlur() like it's done in handleChange() (although I'm still trying to wrap my head around what inputProps are and where they come from). So as a workaround, I am passing only the value (which in this case is hardcoded as 0 because it's the case of an empty string).

Style Q:
Is a blank entry considered valid? Right now, if you type 234 and click out, then click back in and empty the field, the field will show in error state until you click out and onBlur changes it back to not being in error state. Is that desired behavior? (If not, this can be handled either here or on a future PR.)