### PR TITLE
Call empty string valid and store 0 on change

### DIFF
--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -18,7 +18,10 @@ import {
 
 // COMPONENT HELPER FUNCTIONS
 import { getTimeSetter } from '../utils/getTimeSetter';
-import { isPositiveWholeNumber } from '../utils/validators';
+import {
+  isNonNegWholeNumber,
+  hasOnlyNonNegWholeNumberChars,
+} from '../utils/validators';
 
 // OBJECT MANIPULATION
 import { cloneDeep } from 'lodash';
@@ -42,24 +45,24 @@ const Columns = {};
 // `noMargin` is a bit hacky, but it'll do for now
 Columns.One = function ({ noMargin, children }) {
   var marginTop = columnStyle.marginTop;
-  if (noMargin) { 
-    marginTop = 0; 
+  if (noMargin) {
+    marginTop = 0;
   }
   return (<div style={{ ...columnStyle, marginTop: marginTop, width: '5em' }}> {children} </div>);
 };
 
 Columns.Two = function ({ noMargin, children }) {
   var marginTop = columnStyle.marginTop;
-  if (noMargin) { 
-    marginTop = 0; 
+  if (noMargin) {
+    marginTop = 0;
   }
   return (<div style={{ ...columnStyle, marginTop: marginTop, width: '20em', textAlign: 'left', paddingLeft: '1em' }}> {children} </div>);
 };
 
 Columns.Three = function ({ noMargin, children }) {
   var marginTop = columnStyle.marginTop;
-  if (noMargin) { 
-    marginTop = 0; 
+  if (noMargin) {
+    marginTop = 0;
   }
   return (<div style={{ ...columnStyle, marginTop: marginTop, width: '5em' }}> {children} </div>);
 };
@@ -152,7 +155,7 @@ const Role = function ({ member, setMember }) {
 
     var options = [
       { text: 'Spouse of Head of Household', value: 'spouse' },
-      { text: 'Child/Other Household Member', value: 'member' }, 
+      { text: 'Child/Other Household Member', value: 'member' },
     ];
 
     ThisRole = <Dropdown
@@ -225,7 +228,7 @@ const MemberField = function ({ household, time, setHousehold, setClientProperty
             className={ 'remove' }
             onClick={ removeMember }
             iconName={ 'remove' } />
-          : 
+          :
           <span>{ household.length > 1
             ? <Icon
               fitted
@@ -245,13 +248,14 @@ const MemberField = function ({ household, time, setHousehold, setClientProperty
 
       <Columns.Three>
         <ManagedNumberField
-          value      = { member.m_age }
-          name       = { 'm_age' }
-          className  = { time + ' member-age ' + time }
-          validation = { isPositiveWholeNumber }
-          format     = { function (value) { return value; } }
-          store      = { onMemberChange }
-          onBlur     = { function () { return true; } } />
+          value            = { member.m_age }
+          name             = { 'm_age' }
+          className        = { time + ' member-age ' + time }
+          displayValidator = { hasOnlyNonNegWholeNumberChars }
+          storeValidator   = { isNonNegWholeNumber }
+          format           = { function (value) { return value; } }
+          store            = { onMemberChange }
+          onBlur           = { function () { return true; } } />
       </Columns.Three>
 
       <Columns.Four>

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -528,8 +528,7 @@ class ManagedNumberField extends Component {
         className = { className }
         onChange  = { this.handleChange }
         onFocus   = { this.handleFocus }
-        onBlur    = { this.handleBlur }
-        type      = { 'number' } />
+        onBlur    = { this.handleBlur } />
     );
   }  // End render()
 

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -17,7 +17,7 @@ import {
 
 // UTILITIES
 import { toMonthlyAmount } from '../utils/math';
-import { isPositiveNumber } from '../utils/validators';
+import { isNonNegNumber, hasOnlyNonNegNumberChars } from '../utils/validators';
 import { toMoneyStr } from '../utils/prettifiers';
 
 
@@ -494,13 +494,19 @@ class ManagedNumberField extends Component {
   };
 
   handleChange = (evnt, inputProps) => {
-    var { validation, store, otherData } = this.props;
+    var { displayValidator, storeValidator, store, otherData } = this.props;
     var focusedVal = inputProps.value;
+
+    // If doesn't pass display validator, don't store and don't change focusedVal
+    if (!displayValidator(inputProps.value)) {
+      return;
+    }
+
     if (focusedVal.length === 0) {
       // If field contains an empty string, set value to be 0 (visible on blur)
       inputProps.value = '0';
     }
-    var valid = validation(inputProps.value);
+    var valid = storeValidator(inputProps.value);
 
     if (valid) {
       store(evnt, inputProps, otherData);
@@ -583,12 +589,13 @@ const CashFlowRow = function ({ generic, timeState, setClientProperty, children 
    */
   var baseVal   = timeState[ generic ],
       baseProps = {
-        name:       generic,
-        className:  'cashflow-column',
-        store:      updateClient,
-        validation: isPositiveNumber,
-        format:     toMoneyStr,
-        onBlur:     function () { return true; },
+        name:             generic,
+        className:        'cashflow-column',
+        store:            updateClient,
+        displayValidator: hasOnlyNonNegNumberChars,
+        storeValidator:   isNonNegNumber,
+        format:           toMoneyStr,
+        onBlur:           function () { return true; },
       };
 
   return (
@@ -618,7 +625,7 @@ const CashFlowRow = function ({ generic, timeState, setClientProperty, children 
 const MonthlyCashFlowRow = function ({ inputProps, baseValue, setClientProperty, rowProps }) {
 
   inputProps = {
-    ...inputProps, // name, validation, and onBlur
+    ...inputProps, // name, validators, and onBlur
     className: 'cashflow-column',
     format:    toMoneyStr,
     store:     setClientProperty,

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -488,25 +488,24 @@ class ManagedNumberField extends Component {
 
   handleBlur = (evnt) => {
     this.props.onBlur(evnt);
-    // If field is empty string, set value to be 0 so that a user can clear the field
-    var { store, otherData } = this.props;
-    var value = evnt.target.value;
-    if (value.length === 0) {
-      store(evnt, { value: '0' }, otherData);
-    }
+
     // Set local state for blur
     this.setState({ focused: false, valid: true });
   };
 
   handleChange = (evnt, inputProps) => {
     var { validation, store, otherData } = this.props;
-    var { value } = inputProps,
-        valid   = validation(value);
+    var focusedVal = inputProps.value;
+    if (focusedVal.length === 0) {
+      // If field contains an empty string, set value to be 0 (visible on blur)
+      inputProps.value = '0';
+    }
+    var valid = validation(inputProps.value);
 
     if (valid) {
       store(evnt, inputProps, otherData);
     }
-    this.setState({ focusedVal: value, valid: valid });
+    this.setState({ focusedVal: focusedVal, valid: valid });
   };  // End handleChange()
 
   render() {

--- a/src/forms/rentFields.js
+++ b/src/forms/rentFields.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { MonthlyCashFlowRow } from './formHelpers';
 
-import { isPositiveNumber } from '../utils/validators';
+import { isNonNegNumber } from '../utils/validators';
 
 
 class RentShareField extends Component {
@@ -10,7 +10,7 @@ class RentShareField extends Component {
   validation = (ownValue) => {
     var message = null, valid = true;
 
-    let isPosNum = isPositiveNumber(ownValue);
+    let isPosNum = isNonNegNumber(ownValue);
     if (!isPosNum) { 
       valid = false; 
     }
@@ -62,7 +62,7 @@ class ContractRentField extends Component {
   validation = (ownValue) => {
     var message = null, valid = true;
 
-    let isPosNum = isPositiveNumber(ownValue);
+    let isPosNum = isNonNegNumber(ownValue);
     if (!isPosNum) { 
       valid = false; 
     }
@@ -112,7 +112,7 @@ const PlainRentRow = function ({ timeState, setClientProperty }) {
 
   const inputProps = {
           name:       'rent',
-          validation: isPositiveNumber,
+          validation: isNonNegNumber,
           onBlur:     function () {},
         },
         rowProps = {

--- a/src/forms/rentFields.js
+++ b/src/forms/rentFields.js
@@ -1,23 +1,23 @@
 import React, { Component } from 'react';
 import { MonthlyCashFlowRow } from './formHelpers';
 
-import { isNonNegNumber } from '../utils/validators';
+import { isNonNegNumber, hasOnlyNonNegNumberChars } from '../utils/validators';
 
 
 class RentShareField extends Component {
   state = { valid: true, message: null };
 
-  validation = (ownValue) => {
+  storeValidator = (ownValue) => {
     var message = null, valid = true;
 
     let isPosNum = isNonNegNumber(ownValue);
-    if (!isPosNum) { 
-      valid = false; 
+    if (!isPosNum) {
+      valid = false;
     }
     else {
       valid = ownValue <= this.props.timeState[ 'contractRent' ];
-      if (!valid) { 
-        message = 'Rent share must be less than contract rent'; 
+      if (!valid) {
+        message = 'Rent share must be less than contract rent';
       }
     }
 
@@ -34,9 +34,10 @@ class RentShareField extends Component {
           { valid, message } = this.state;
 
     const inputProps = {
-            name:       'rentShare',
-            validation: this.validation,
-            onBlur:     this.onBlur,
+            name:             'rentShare',
+            displayValidator: hasOnlyNonNegNumberChars,
+            storeValidator:   this.storeValidator,
+            onBlur:           this.onBlur,
           },
           rowProps = {
             label:    'Your Monthly Rent Share (how much of the total rent you have to pay)',
@@ -59,17 +60,17 @@ class RentShareField extends Component {
 class ContractRentField extends Component {
   state = { valid: true, message: null };
 
-  validation = (ownValue) => {
+  storeValidator = (ownValue) => {
     var message = null, valid = true;
 
     let isPosNum = isNonNegNumber(ownValue);
-    if (!isPosNum) { 
-      valid = false; 
+    if (!isPosNum) {
+      valid = false;
     }
     else {
       valid = ownValue >= this.props.timeState[ 'rentShare' ];
-      if (!valid) { 
-        message = 'Rent share must be less than contract rent'; 
+      if (!valid) {
+        message = 'Rent share must be less than contract rent';
       }
     }
 
@@ -86,9 +87,10 @@ class ContractRentField extends Component {
           { valid, message } = this.state;
 
     const inputProps = {
-            name:       'contractRent',
-            validation: this.validation,
-            onBlur:     this.onBlur,
+            name:             'contractRent',
+            displayValidator: hasOnlyNonNegNumberChars,
+            storeValidator:   this.storeValidator,
+            onBlur:           this.onBlur,
           },
           rowProps = {
             label:    'Monthly Contract Rent (the total rent for your apartment)',
@@ -111,9 +113,10 @@ class ContractRentField extends Component {
 const PlainRentRow = function ({ timeState, setClientProperty }) {
 
   const inputProps = {
-          name:       'rent',
-          validation: isNonNegNumber,
-          onBlur:     function () {},
+          name:             'rent',
+          displayValidator: hasOnlyNonNegNumberChars,
+          storeValidator:   isNonNegNumber,
+          onBlur:           function () {},
         },
         rowProps = {
           label:    'Monthly Rent',

--- a/src/index.css
+++ b/src/index.css
@@ -76,7 +76,7 @@ Used to fill vertical space.
   padding-left: 1em !important;
 }
 
-.ui.form .cashflow .cashflow-column .ui.input input[type="number"] {
+.ui.form .cashflow .cashflow-column .ui.input input {
   text-align: right;
   width: 7em;
   display: inline-block;

--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -59,19 +59,20 @@ test('should set focused state to false on blur', () => {
 });
 
 test('should change local and app state correctly when user inputs positive number', () => {
-  const mockValidation = jest.fn();
+  const mockValidator = jest.fn();
   const mockStore = jest.fn();
 
   // Define the test case here
   const userInput = 5;
-  mockValidation.mockReturnValue(true);
+  mockValidator.mockReturnValue(true);
 
   const wrapper = shallow(
     <ManagedNumberField
       format={ () => {} }
       otherData={ null }
       store={ mockStore }
-      validation={ mockValidation }
+      storeValidator={ mockValidator }
+      displayValidator={ mockValidator }
       value={ 0 } />
   );
   wrapper.find('FormInput').simulate('change', {}, { value: userInput });
@@ -86,19 +87,20 @@ test('should change local and app state correctly when user inputs positive numb
 });
 
 test('should change local and app state correctly when user inputs empty string', () => {
-  const mockValidation = jest.fn();
+  const mockValidator = jest.fn();
   const mockStore = jest.fn();
 
   // Define the test case here
   const userInput = '';
-  mockValidation.mockReturnValue(true);
+  mockValidator.mockReturnValue(true);
 
   const wrapper = shallow(
     <ManagedNumberField
       format={ () => {} }
       otherData={ null }
       store={ mockStore }
-      validation={ mockValidation }
+      displayValidator={ mockValidator }
+      storeValidator={ mockValidator }
       value={ 0 } />
   );
   wrapper.find('FormInput').simulate('change', {}, { value: userInput });
@@ -113,19 +115,20 @@ test('should change local and app state correctly when user inputs empty string'
 });
 
 test('should change local and app state correctly when user inputs negative number', () => {
-  const mockValidation = jest.fn();
+  const mockValidator = jest.fn();
   const mockStore = jest.fn();
 
   // Define the test case here
   const userInput = -6;
-  mockValidation.mockReturnValue(false);
+  mockValidator.mockReturnValue(false);
 
   const wrapper = shallow(
     <ManagedNumberField
       format={ () => {} }
       otherData={ null }
       store={ mockStore }
-      validation={ mockValidation }
+      displayValidator={ mockValidator }
+      storeValidator={ mockValidator }
       value={ 0 } />
   );
   wrapper.find('FormInput').simulate('change', {}, { value: userInput });

--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ManagedNumberField } from '../../forms/formHelpers';
+import { isNonNegNumber, hasOnlyNonNegNumberChars } from '../../utils/validators';
 
 test('ManagedNumberField should match snapshot', () => {
   const wrapper = shallow(
@@ -115,30 +116,36 @@ test('should change local and app state correctly when user inputs empty string'
 });
 
 test('should change local and app state correctly when user inputs negative number', () => {
-  const mockValidator = jest.fn();
   const mockStore = jest.fn();
 
+  var mockDisplayValidator = jest.fn();
+  mockDisplayValidator.mockImplementation(hasOnlyNonNegNumberChars);
+
+  var mockStoreValidator = jest.fn();
+  mockStoreValidator.mockImplementation(isNonNegNumber);
+
   // Define the test case here
-  const userInput = -6;
-  mockValidator.mockReturnValue(false);
+  const userInput1 = 6;
+  const userInput2 = -6;
 
   const wrapper = shallow(
     <ManagedNumberField
       format={ () => {} }
       otherData={ null }
       store={ mockStore }
-      displayValidator={ mockValidator }
-      storeValidator={ mockValidator }
+      displayValidator={ mockDisplayValidator }
+      storeValidator={ mockStoreValidator }
       value={ 0 } />
   );
-  wrapper.find('FormInput').simulate('change', {}, { value: userInput });
+  wrapper.find('FormInput').simulate('change', {}, { value: userInput1 });
+  wrapper.find('FormInput').simulate('change', {}, { value: userInput2 });
 
   // expect that the store has not been called
-  expect(mockStore).not.toHaveBeenCalled();
+  expect(mockStore.mock.calls).toHaveLength(1);
 
   // changes to this.state's focusedVal and valid variables
-  expect(wrapper.state('focusedVal')).toBe(userInput);
-  expect(wrapper.state('valid')).toBe(false);
+  expect(wrapper.state('focusedVal')).toBe(userInput1);
+  expect(wrapper.state('valid')).toBe(true);
 });
 
 test('should set FormInput error state properly when valid condition changes', () => {

--- a/src/test/forms/ManagedNumberField.test.js
+++ b/src/test/forms/ManagedNumberField.test.js
@@ -91,7 +91,7 @@ test('should change local and app state correctly when user inputs empty string'
 
   // Define the test case here
   const userInput = '';
-  mockValidation.mockReturnValue(false);
+  mockValidation.mockReturnValue(true);
 
   const wrapper = shallow(
     <ManagedNumberField
@@ -109,7 +109,7 @@ test('should change local and app state correctly when user inputs empty string'
 
   // changes to this.state's focusedVal and valid variables
   expect(wrapper.state('focusedVal')).toBe(userInput);
-  expect(wrapper.state('valid')).toBe(false);
+  expect(wrapper.state('valid')).toBe(true);
 });
 
 test('should change local and app state correctly when user inputs negative number', () => {

--- a/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
+++ b/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
@@ -8,6 +8,7 @@ exports[`CashFlowRow should match snapshot 1`] = `
 >
   <ManagedNumberField
     className="cashflow-column"
+    displayValidator={[Function]}
     format={[Function]}
     name="name"
     onBlur={[Function]}
@@ -17,11 +18,12 @@ exports[`CashFlowRow should match snapshot 1`] = `
       }
     }
     store={[Function]}
-    validation={[Function]}
+    storeValidator={[Function]}
     value={0}
   />
   <ManagedNumberField
     className="cashflow-column"
+    displayValidator={[Function]}
     format={[Function]}
     name="name"
     onBlur={[Function]}
@@ -31,11 +33,12 @@ exports[`CashFlowRow should match snapshot 1`] = `
       }
     }
     store={[Function]}
-    validation={[Function]}
+    storeValidator={[Function]}
     value={0}
   />
   <ManagedNumberField
     className="cashflow-column"
+    displayValidator={[Function]}
     format={[Function]}
     name="name"
     onBlur={[Function]}
@@ -45,7 +48,7 @@ exports[`CashFlowRow should match snapshot 1`] = `
       }
     }
     store={[Function]}
-    validation={[Function]}
+    storeValidator={[Function]}
     value={0}
   />
 </CashFlowContainer>

--- a/src/test/forms/__snapshots__/ManagedNumberField.test.js.snap
+++ b/src/test/forms/__snapshots__/ManagedNumberField.test.js.snap
@@ -8,6 +8,5 @@ exports[`ManagedNumberField should match snapshot 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
-  type="number"
 />
 `;

--- a/src/test/utils/validators.test.js
+++ b/src/test/utils/validators.test.js
@@ -1,46 +1,46 @@
-import { isPositiveNumber, isPositiveWholeNumber } from '../../utils/validators';
+import { isNonNegNumber, isNonNegWholeNumber } from '../../utils/validators';
 
 
-test('isPositiveNumber()', () => {
-  expect(isPositiveNumber('.05 * 10^3')).toBeFalsy();
-  expect(isPositiveNumber('.5e3')).toBeFalsy();
-  expect(isPositiveNumber('5 * 10^3')).toBeFalsy();
-  expect(isPositiveNumber('5e3')).toBeFalsy();
+test('isNonNegNumber()', () => {
+  expect(isNonNegNumber('.05 * 10^3')).toBeFalsy();
+  expect(isNonNegNumber('.5e3')).toBeFalsy();
+  expect(isNonNegNumber('5 * 10^3')).toBeFalsy();
+  expect(isNonNegNumber('5e3')).toBeFalsy();
 
-  expect(isPositiveNumber('4.67')).toBeTruthy();
-  expect(isPositiveNumber('.98')).toBeTruthy();
-  expect(isPositiveNumber('0.333')).toBeTruthy();
-  expect(isPositiveNumber('56.8')).toBeTruthy();
-  expect(isPositiveNumber('6')).toBeTruthy();
+  expect(isNonNegNumber('4.67')).toBeTruthy();
+  expect(isNonNegNumber('.98')).toBeTruthy();
+  expect(isNonNegNumber('0.333')).toBeTruthy();
+  expect(isNonNegNumber('56.8')).toBeTruthy();
+  expect(isNonNegNumber('6')).toBeTruthy();
 
-  expect(isPositiveNumber('-4.67')).toBeFalsy();
-  expect(isPositiveNumber('-.98')).toBeFalsy();
-  expect(isPositiveNumber('-0.333')).toBeFalsy();
-  expect(isPositiveNumber('-56.8')).toBeFalsy();
-  expect(isPositiveNumber('-6')).toBeFalsy();
+  expect(isNonNegNumber('-4.67')).toBeFalsy();
+  expect(isNonNegNumber('-.98')).toBeFalsy();
+  expect(isNonNegNumber('-0.333')).toBeFalsy();
+  expect(isNonNegNumber('-56.8')).toBeFalsy();
+  expect(isNonNegNumber('-6')).toBeFalsy();
 
 });
 
-test('isPositiveWholeNumber()', () => {
-  expect(isPositiveWholeNumber('.05 * 10^3')).toBeFalsy();
-  expect(isPositiveWholeNumber('.5e3')).toBeFalsy();
-  expect(isPositiveWholeNumber('5 * 10^3')).toBeFalsy();
-  expect(isPositiveWholeNumber('5e3')).toBeFalsy();
+test('isNonNegWholeNumber()', () => {
+  expect(isNonNegWholeNumber('.05 * 10^3')).toBeFalsy();
+  expect(isNonNegWholeNumber('.5e3')).toBeFalsy();
+  expect(isNonNegWholeNumber('5 * 10^3')).toBeFalsy();
+  expect(isNonNegWholeNumber('5e3')).toBeFalsy();
 
-  expect(isPositiveWholeNumber('5')).toBeTruthy();
-  expect(isPositiveWholeNumber('-5')).toBeFalsy();
+  expect(isNonNegWholeNumber('5')).toBeTruthy();
+  expect(isNonNegWholeNumber('-5')).toBeFalsy();
 
-  expect(isPositiveWholeNumber('4.67')).toBeFalsy();
-  expect(isPositiveWholeNumber('0.333')).toBeFalsy();
-  expect(isPositiveWholeNumber('56.8')).toBeFalsy();
-  expect(isPositiveWholeNumber('6.')).toBeFalsy();
+  expect(isNonNegWholeNumber('4.67')).toBeFalsy();
+  expect(isNonNegWholeNumber('0.333')).toBeFalsy();
+  expect(isNonNegWholeNumber('56.8')).toBeFalsy();
+  expect(isNonNegWholeNumber('6.')).toBeFalsy();
 
-  expect(isPositiveWholeNumber('-4.67')).toBeFalsy();
-  expect(isPositiveWholeNumber('-0.333')).toBeFalsy();
-  expect(isPositiveWholeNumber('-56.8')).toBeFalsy();
-  expect(isPositiveWholeNumber('-6.')).toBeFalsy();
+  expect(isNonNegWholeNumber('-4.67')).toBeFalsy();
+  expect(isNonNegWholeNumber('-0.333')).toBeFalsy();
+  expect(isNonNegWholeNumber('-56.8')).toBeFalsy();
+  expect(isNonNegWholeNumber('-6.')).toBeFalsy();
 
-  expect(isPositiveWholeNumber('A')).toBeFalsy();
-  expect(isPositiveWholeNumber('A.')).toBeFalsy();
-  expect(isPositiveWholeNumber('AA')).toBeFalsy();
+  expect(isNonNegWholeNumber('A')).toBeFalsy();
+  expect(isNonNegWholeNumber('A.')).toBeFalsy();
+  expect(isNonNegWholeNumber('AA')).toBeFalsy();
 });

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -4,22 +4,33 @@
  * numbers right now.
  */
 
+/** Returns true if a string only contains characters for a nonnegative number */
+const hasOnlyNonNegNumberChars = function (str) {
+  return /^[0-9.]*$/.test(str);
+};
+
+/** Returns true if a string only contains characters for a nonnegative whole number */
+const hasOnlyNonNegWholeNumberChars = function (str) {
+  return /^[0-9]*$/.test(str);
+};
 
 /** Returns true if a string represents a positve number (integer or float) */
 // Should this only be valid if it has <= 2 decimal places?
-const isPositiveNumber = function (str) {
+const isNonNegNumber = function (str) {
   return str !== '' && !/[^0-9.]|\..*\./.test(str);
 };
 
 
 /** Returns true if a string represents a positive integer */
 /** @todo Change name to 'isWholeNumber'. */
-const isPositiveWholeNumber = function (str) {
+const isNonNegWholeNumber = function (str) {
   return str !== '' && /^[0-9]*$/.test(str);
 };
 
 
 export {
-  isPositiveNumber,
-  isPositiveWholeNumber,
+  hasOnlyNonNegNumberChars,
+  hasOnlyNonNegWholeNumberChars,
+  isNonNegNumber,
+  isNonNegWholeNumber,
 };


### PR DESCRIPTION
Fixes the failure of one test from #622, which occurs because we were treating empty strings in a `ManagedNumberField` as invalid while it's focused, and only defaulting to '0' and storing the '0' on blur. This moves that logic to the `handleChange` function, so that empty strings are stored and validated as '0' while focused (meaning they will be seen as valid by `isPositiveNumber`), while keeping the empty string in `focusedVal`. I also modified the test to return `true` from the validation function and expect the field to be valid, since the call to `store` is only supposed to happen if it's valid.