### PR TITLE
Add CodeCov shield for create react app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 cache:
   directories:
     - node_modules
+install:
+  - npm install -g codecov
 script:
   - npm run build
-  - npm test
+  - npm test -- --coverage && codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cliff-effects [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects)
+# cliff-effects  [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects) [![CodeCov](https://img.shields.io/codecov/c/github/codeforboston/cliff-effects.svg)](https://codecov.io/gh/codeforboston/cliff-effects)
 > **cliff effect**: You are a person on government benefits, and you get a raise.  You're making more money!  But now that your income is higher, you don't make the cutoff for the benefits you receive.  Even though you're taking home more money, your situation is worse. Some of your benefits drop to nothing, or almost nothing. You've fallen off "the cliff."
 
 We are building the Cliff Effects webapp to help* [Project Hope](http://www.prohope.org/about/) case managers make quantifiable predictions about their clients' potential cliff effects - and advise their clients accordingly.


### PR DESCRIPTION
I will be adding to the documentation for this pull request after it has been merged or closed. To improve readability of the process for setting code coverage up on a create react app. 

link1: [code coverage from create react app issues page](https://github.com/facebook/create-react-app/issues/2825) 
link2: [code coverage from create react app docs](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#coverage-reporting)
link3: [use yarn test instead of npm test](https://github.com/facebook/create-react-app/issues/1363) 

Lastly, codecov needed to be installed to get the shield.
Codecov is a global npm package installed when running TravisCI or CircleCI that hosts your previous and current code coverage information to show the projects progression over time.
Running codecov after the files have been written to the coverage folder, sends the coverage folder info to the codecov website. This service is free for open source projects.