### PR TITLE
Add Code coverage command 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 cache:
   directories:
     - node_modules
+install:
+  - npm install -g codecov
 script:
   - npm run build
-  - npm test
+  - yarn test -- --coverage && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - npm install -g codecov
 script:
   - npm run build
-  - yarn test -- --coverage && codecov
+  - npm test -- --coverage && codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cliff-effects [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects)
+# cliff-effects  [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects) [![CodeCov](https://img.shields.io/codecov/c/github/codeforboston/cliff-effects.svg)](https://codecov.io/gh/codeforboston/cliff-effects)
 > **cliff effect**: You are a person on government benefits, and you get a raise.  You're making more money!  But now that your income is higher, you don't make the cutoff for the benefits you receive.  Even though you're taking home more money, your situation is worse. Some of your benefits drop to nothing, or almost nothing. You've fallen off "the cliff."
 
 We are building the Cliff Effects webapp to help* [Project Hope](http://www.prohope.org/about/) case managers make quantifiable predictions about their clients' potential cliff effects - and advise their clients accordingly.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "coverage": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "deploy": "npm run build&&gh-pages -d build",
     "generateSNAPTests": "./node_modules/.bin/babel-node src/test/programs/federal/snap/generateTestCases",


### PR DESCRIPTION
Same as #631, but with an additional package json script 
For giving line coverage when the test suite runs.

If adding a new script is not useful. 
the test script itself can be changed to include coverage every time someone runs the test suite.

Options, 
1) #631, ```npm run test -- --coverage``` inside the .travis.yml
2) #632, this pull request: same as #631 but adding coverage script to the package.json: 
```npm run coverage```. Additionally the .travis.yml could ```npm run coverage``` but I feel that is against convention because someone might decide to delete the coverage script one day.
3) #634,  Change the test command in `package.json` to: 
```"test": "react-scripts test -- --coverage",```
then the .travis.yml only needs to perform `npm run test`

I can modify #631 to have these changes if we want all of the discussion info housed in that pr. 
I am adding all of the test info to a wiki page for the project.