### PR TITLE
fix test suite, hoping for discussion.

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -506,6 +506,9 @@ class ManagedNumberField extends Component {
     if (valid) {
       store(evnt, inputProps, otherData);
     }
+    else if (value.length === 0) {  // treat empty string as 0
+      store(evnt, { ...inputProps, value: '0' }, otherData);
+    }
     this.setState({ focusedVal: value, valid: valid });
   };  // End handleChange()
 


### PR DESCRIPTION
#625, has caused future Travis CI builds to fail because of failing test:
```bash 
 FAIL  src/test/forms/ManagedNumberField.test.js
  ● should change local and app state correctly when user inputs empty string

    TypeError: Cannot read property '1' of undefined
```
@snyderc, I wanted to see if the change in this PR to put back in the value = "0" was acceptable.
I left the blur change in the code, hopefully it still achieves your objective.

Either the blur has a job but this code needs back in,
the blur is not doing its job but could do the job.
or the test needs to be rewritten for the new changes.

If we cant get this resolved maybe #625 should be reverted and that pull request be submitted again with another code review.

Hopefully this will bring up positive discussion. Im having a hard time understanding, because the blur does bring in the values. But does not change the state in the test. Could this be because the blur only fires after a value has changed on the predictions page and a click away from the value column, maybe the test is before that event.