### PR TITLE
Add code coverage to test script in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - npm install -g codecov
 script:
   - npm run build
-  - npm test -- --coverage && codecov
+  - npm test && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 cache:
   directories:
     - node_modules
+install:
+  - npm install -g codecov
 script:
   - npm run build
-  - npm test
+  - npm test -- --coverage && codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cliff-effects [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects)
+# cliff-effects  [![TravisCI](https://travis-ci.org/codeforboston/cliff-effects.svg?style=shield)](https://travis-ci.org/codeforboston/cliff-effects) [![CodeCov](https://img.shields.io/codecov/c/github/codeforboston/cliff-effects.svg)](https://codecov.io/gh/codeforboston/cliff-effects)
 > **cliff effect**: You are a person on government benefits, and you get a raise.  You're making more money!  But now that your income is higher, you don't make the cutoff for the benefits you receive.  Even though you're taking home more money, your situation is worse. Some of your benefits drop to nothing, or almost nothing. You've fallen off "the cliff."
 
 We are building the Cliff Effects webapp to help* [Project Hope](http://www.prohope.org/about/) case managers make quantifiable predictions about their clients' potential cliff effects - and advise their clients accordingly.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "deploy": "npm run build&&gh-pages -d build",
     "generateSNAPTests": "./node_modules/.bin/babel-node src/test/programs/federal/snap/generateTestCases",


### PR DESCRIPTION
@wacii, does this example satisfy what you are looking for to declutter the ```.travis.yml```?

Options, 
1) #631, ```npm run test -- --coverage``` inside the .travis.yml
2) #632, same as this pr but adding coverage script to the package.json: `npm run coverage`.
3) #634, this pull request: Change the test command in `package.json` to: 
```"test": "react-scripts test -- --coverage",```
then the .travis.yml only needs to perform `npm run test`

I can modify #631 to have these changes if we want all of the discussion info housed in that pr. 

Added documentation to the project, [here](https://github.com/codeforboston/cliff-effects/wiki/Guide:-Code-Coverage-with-%22react-scripts-test%22)