### PR TITLE
Spelling out SNAP on the first page of the form

### DIFF
--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -132,7 +132,7 @@ export default {
         hint:  'Section 8 provides rental housing assistance.',
       },
       hasSnap: {
-        label: 'Do you have SNAP?',
+        label: 'Do you have SNAP (Supplemental Nutrition Assistance Program)?',
         hint:  'SNAP provides assistance with buying food',
       },
       next: 'Next',


### PR DESCRIPTION
Provides the spelled-out version of SNAP (Supplemental Nutrition Assistance Program) in addition to the acronym. For clarity & for making it easier to translate into other languages.

This came up today while going through translations with a volunteer translator.