### PR TITLE
No CodeCov comment in pull request.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Here are the docs related to this pull request. 
https://docs.codecov.io/v4.3.6/docs/pull-request-comments

Current commit removes any comments CodeCov would implement.

However, the CodeCov yml can be customized further to comment individually regarding:
"reach, diff, flags, files"

CodeCov can also "only post the comment if coverage changes"

@knod 
If those additions are not needed this pr should be fine for removing the diff from every pr.

for example if you only wanted the graph you would put, "reach"
in the config.yml file as noted in the [doc](https://docs.codecov.io/v4.3.6/docs/pull-request-comments)
```
Reach is a coverage graph embedded into the comment.
Learn more here: Graphs: Reach.
```

This is what it looks like if you include the graph:
https://github.com/MichaelDimmitt/cliff-effects/pull/2

But not the other information in the CodeCov comment for pull requests.