### PR TITLE
Parker/issue #542 remove checkmarks

### DIFF
--- a/src/components/StepBar.js
+++ b/src/components/StepBar.js
@@ -7,7 +7,6 @@ const StepBar = ({ steps, currentStepIndex, goToStep, snippets }) => {
 
   steps.forEach((step, index) => {
     var newStep = { title: snippets[ step.key ] };
-    newStep.completed = index < currentStepIndex;
     newStep.active = index === (currentStepIndex - 1);
     newStep.onClick = (e) => {
       goToStep(index + 1); 


### PR DESCRIPTION
Changed StepBar to no longer mark steps as completed, which means that check marks will not appear in the steps.

I couldn't find anywhere else that cared whether or not `completed` was true, but maybe someone more familiar with semantic-ui-react/this project could confirm before merging this.