### PR TITLE
Moves headings to their own file - issue #670

### DIFF
--- a/src/components/headings.js
+++ b/src/components/headings.js
@@ -1,0 +1,151 @@
+// REACT COMPONENTS
+import React from 'react';
+import { Header } from 'semantic-ui-react';
+
+
+/** h1 styles available for form (and other) text.
+*
+* @function
+* @param {object} props
+* @property {string} props.subheading - For when some
+*     kind of clarifier is needed.
+* @property {object} props.children - Ususally a string
+*     to be shown as the heading text.
+*
+* @returns Component
+*/
+const ContentH1 = function ({ subheading, children }) {
+
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <div className={ 'text-h1' } >
+      <div /> {/** div here to make sure header margin doesn\'t collapse */}
+      <Header
+        as='h3'
+        style={{ display: 'inline-block' }}>
+        { children }
+      </Header>
+      <ContentSubH1>{ subheading }</ContentSubH1>
+      <br />
+    </div>
+  );
+
+};  // End ContentH1{} Component
+
+
+/** A clearer way than a ternary operator to have a possible
+* subheader and separate styling.
+*
+* @function
+* @param {object} props
+* @property {object} props.children - Contents of this element
+*
+* @returns Component
+*/
+const ContentSubH1 = function ({ children }) {
+
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <div
+      className = { 'text-sub-h1' }
+      style={{ display: 'block', textAlign: 'left' }}>
+      { children }
+    </div>
+  );
+
+};  // End ContentSubH1{} Component
+
+
+/* To discuss: Should form-specific headings be in a different file? */
+
+
+/** Weekly/Monthly/Yearly headings combined for the
+*     top of columns that need those time intervals.
+*
+* @function
+* @param {object} props
+* @property {object} props.type - Very fragile. Used to
+*     create the heading for the column for labels of the
+*     inputs - labels like 'Earned Income'. This was created
+*     for income and expenses columns to try to cue the user
+*     about the info they were putting in. The current uses
+*     are to create the headings 'Income Type' and 'Expenses
+*     Type', so the user will have an extra hint about what
+*     information they should be giving at that moment.
+*
+* @returns Component
+*/
+const IntervalColumnHeadings = function ({ type }) {
+
+  var columnTitle = type.toLowerCase().replace(/\b[a-z]/g, (letter) => {
+        return letter.toUpperCase();
+      }) + ' Type',
+      styles      = { fontSize: '14px' };
+
+  return (
+    <div style={{ display: 'inline-block' }}>
+      <ColumnHeading
+        type={ type }
+        colName='weekly'
+        style={ styles }>Weekly
+      </ColumnHeading>
+      <ColumnHeading
+        type={ type }
+        colName='monthly'
+        style={ styles }>Monthly
+      </ColumnHeading>
+      <ColumnHeading
+        type={ type }
+        colName='yearly'
+        style={ styles }>Yearly
+      </ColumnHeading>
+      <ColumnHeading
+        type={ type }
+        colName={ type }
+        style={ styles }
+        columnTitle={ columnTitle }>{columnTitle}
+      </ColumnHeading>
+    </div>
+  );
+
+};  // End <IntervalColumnHeadings>
+
+
+/** Style for text at the tops of columns, like
+*     cashflow or household columns.
+*
+* @function
+* @param {object} props
+* @property {string} props.type - Used for element classes
+* @property {string} props.colName - Also for the element classes
+* @property {object} props.style - Style override
+* @property {object} props.children - Usually the heading text
+*
+* @returns Component
+*/
+const ColumnHeading = function ({ type, colName, style, children }) {
+  var classes = type + '-column cashflow-column header ' + colName;
+  return (
+    <Header
+      as='h4'
+      className={ classes }
+      style={ style }
+      color='teal'>
+      { children }
+    </Header>
+  );
+};  // End <ColumnHeading>
+
+
+export {
+  ContentH1,
+  ContentSubH1,
+  ColumnHeading,
+  IntervalColumnHeadings,
+};

--- a/src/forms/CurrentExpenses.js
+++ b/src/forms/CurrentExpenses.js
@@ -10,12 +10,14 @@ import {
 // PROJECT COMPONENTS
 import {
   FormPartsContainer,
-  FormHeading,
-  IntervalColumnHeadings,
   CashFlowRow,
   ControlledRadioYesNo,
   AttentionArrow,
 } from './formHelpers';
+import {
+  ContentH1,
+  IntervalColumnHeadings,
+} from '../components/headings';
 import {
   ContractRentField,
   RentShareField,
@@ -217,7 +219,7 @@ const Housing = function ({ current, type, time, setClientProperty }) {
   return (
     <div>
 
-      <FormHeading>Housing</FormHeading>
+      <ContentH1>Housing</ContentH1>
 
       { current.housing === 'voucher'
         ? null
@@ -291,9 +293,9 @@ const ExpensesFormContent = function ({ current, time, setClientProperty, snippe
       { under13.length > 0
         ? 
         <div>
-          <FormHeading subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
+          <ContentH1 subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
             { snippets.unreimbursedNonMedicalChildCare.sectionHeading }
-          </FormHeading>
+          </ContentH1>
           <IntervalColumnHeadings type={ type } />
           <CashFlowRow
             { ...sharedProps }
@@ -332,7 +334,7 @@ const ExpensesFormContent = function ({ current, time, setClientProperty, snippe
       { current.hasSnap
         ? 
         <div>
-          <FormHeading>Child Support</FormHeading>
+          <ContentH1>Child Support</ContentH1>
           <IntervalColumnHeadings type={ type } />
           <CashFlowRow
             { ...sharedProps }
@@ -346,9 +348,9 @@ const ExpensesFormContent = function ({ current, time, setClientProperty, snippe
       { over12.length > 0
         ? 
         <div>
-          <FormHeading subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
+          <ContentH1 subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
             Dependent Care of Persons Over 12 Years of Age
-          </FormHeading>
+          </ContentH1>
           <IntervalColumnHeadings type={ type } />
           <CashFlowRow
             { ...sharedProps }
@@ -369,7 +371,7 @@ const ExpensesFormContent = function ({ current, time, setClientProperty, snippe
       { elderlyOrDisabled.length > 0
         ? 
         <div>
-          <FormHeading>Unreimbursed Disabled/Handicapped/Elderly Assistance</FormHeading>
+          <ContentH1>Unreimbursed Disabled/Handicapped/Elderly Assistance</ContentH1>
           <div>Unreimbursed expenses to cover care attendants and auxiliary apparatus for any family member who is elderly or is a person with disabilities. Auxiliary apparatus are items such as wheelchairs, ramps, adaptations to vehicles, or special equipment to enable a blind person to read or type, but only if these items are directly related to permitting the disabled person or other family member to work.</div>
           <div>Examples of eligible disability assistance expenses:</div>
           <ul>
@@ -402,7 +404,7 @@ const ExpensesFormContent = function ({ current, time, setClientProperty, snippe
       { elderlyOrDisabledHeadOrSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0)
         ? 
         <div>
-          <FormHeading>Unreimbursed Medical Expenses</FormHeading>
+          <ContentH1>Unreimbursed Medical Expenses</ContentH1>
           <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
           <ul>
             <li>The orthodontist expenses for a child’s braces.</li>

--- a/src/forms/CurrentIncome.js
+++ b/src/forms/CurrentIncome.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { Form } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
-import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formHelpers';
+import { FormPartsContainer, CashFlowRow } from './formHelpers';
+import { IntervalColumnHeadings } from '../components/headings';
 
 // COMPONENT HELPER FUNCTIONS
 import { getTimeSetter } from '../utils/getTimeSetter';

--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -12,9 +12,9 @@ import {
 // PROJECT COMPONENTS
 import {
   FormPartsContainer,
-  ColumnHeading,
   ManagedNumberField,
 } from './formHelpers';
+import { ColumnHeading } from '../components/headings';
 
 // COMPONENT HELPER FUNCTIONS
 import { getTimeSetter } from '../utils/getTimeSetter';

--- a/src/forms/Predictions.js
+++ b/src/forms/Predictions.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Form, Divider, Header, Tab } from 'semantic-ui-react';
 
 // PROJECT COMPONENTS
-import { FormPartsContainer, IntervalColumnHeadings, CashFlowRow } from './formHelpers';
+import { FormPartsContainer, CashFlowRow } from './formHelpers';
+import { IntervalColumnHeadings } from '../components/headings';
 import { GraphHolder } from './output/GraphHolder';
 import { BenefitsTable } from './output/BenefitsTable';
 import { StackedBarGraph } from './output/StackedBarGraph';

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -225,62 +225,6 @@ const MassiveToggle = function (props) {
 };  // End MassiveToggle{} Component
 
 
-/** A clearer way than a ternary operator to have a possible
-* subheader. Also, clearer for separate styling
-*
-* @function
-* @param {object} props
-* @property {object} props.children - Contents of this element
-*
-* @returns Component
-*/
-const FormSubheading = function (props) {
-
-  if (!props.children) {
-    return null;
-  }
-
-  return (
-    <div
-      className = { 'form-subheading' }
-      style={{ display: 'block', textAlign: 'left' }}>
-      { props.children }
-    </div>
-  );
-
-};  // End FormSubheading{} Component
-
-
-/** @todo description
-*
-* @function
-* @param {object} props
-* @property {object} props.__ - explanation
-*
-* @returns Component
-*/
-const FormHeading = function ({ subheading, children }) {
-
-  if (!children) {
-    return null;
-  }
-
-  return (
-    <div className={ 'form-heading' } >
-      <div /> {/** div here to make sure header margin doesn\'t collapse */}
-      <Header
-        as='h3'
-        style={{ display: 'inline-block' }}>
-        { children }
-      </Header>
-      <FormSubheading>{subheading}</FormSubheading>
-      <br />
-    </div>
-  );
-
-};  // End FormHeading{} Component
-
-
 /** @todo description
 *
 * @function
@@ -396,71 +340,6 @@ const RowMessage = function ({ validRow, message }) {
 //     className='right-column'
 //     name='Earned Income' placeholder='Earned Income'
 //   />
-
-
-/** @todo description
-*
-* @function
-* @param {object} props
-* @property {object} props.__ - explanation
-*
-* @returns Component
-*/
-const ColumnHeading = function ({ type, colName, style, children }) {
-  var classes = type + '-column cashflow-column header ' + colName;
-  return (
-    <Header
-      as='h4'
-      className={ classes }
-      style={ style }
-      color='teal'>{children}
-    </Header>
-  );
-};  // End ColumnHeading()
-
-
-/** @todo description
-*
-* @function
-* @param {object} props
-* @property {object} props.__ - explanation
-*
-* @returns Component
-*/
-const IntervalColumnHeadings = function ({ type }) {
-
-  var columnTitle = type.toLowerCase().replace(/\b[a-z]/g, (letter) => {
-        return letter.toUpperCase();
-      }) + ' Type',
-      styles      = { fontSize: '14px' };
-
-  return (
-    <div style={{ display: 'inline-block' }}>
-      <ColumnHeading
-        type={ type }
-        colName='weekly'
-        style={ styles }>Weekly
-      </ColumnHeading>
-      <ColumnHeading
-        type={ type }
-        colName='monthly'
-        style={ styles }>Monthly
-      </ColumnHeading>
-      <ColumnHeading
-        type={ type }
-        colName='yearly'
-        style={ styles }>Yearly
-      </ColumnHeading>
-      <ColumnHeading
-        type={ type }
-        colName={ type }
-        style={ styles }
-        columnTitle={ columnTitle }>{columnTitle}
-      </ColumnHeading>
-    </div>
-  );
-
-};  // End IntervalColumnHeadings{} Component
 
 
 /**
@@ -733,10 +612,10 @@ export {
   ExternalLink, SpaceHolder,
   BottomButton, FormBottomRow,
   FormPartsContainer,
-  MassiveToggle, FormSubheading, FormHeading,
+  MassiveToggle,
   InlineLabelInfo,
   RowMessage,
-  IntervalColumnHeadings, ColumnHeading, ManagedNumberField,
+  ManagedNumberField,
   CashFlowRow, MonthlyCashFlowRow, CashFlowContainer,
   ControlledRadioYesNo, AttentionArrow,
 };

--- a/src/localization/de.js
+++ b/src/localization/de.js
@@ -64,8 +64,8 @@ export default {
     whoMadeThis2C: ` aufrecht. Für weitere Auskunft treten Sie bitte in Verbindung mit `,
     whoMadeThis2D: `.`,
     
-    whoMadeThis3Intro: `Wir möchten den folgenden Freiwilligen von Code for Boston besonders danken: `,
-    whoMadeThis3Names: `Annie LaCourt, Isaac Chansky, Michelle Bernstein, Alec Danaher, Sasha Maryl, Drew Love, Liani Lye, Andrew Cunningham, Liam Morley, Nick Francisci, Stephen Chin, Shameek Poddar, Will McIntosh, Andrew Seeder, Ben Lewis, Don Blair, Ethan Strominger, Nick Lee, Jonathan Marcus, Emily Wasserman, Ethan Blackwood,`,
+    whoMadeThis3Intro:     `Wir möchten den folgenden Freiwilligen von Code for Boston besonders danken: `,
+    whoMadeThis3Names:     `Annie LaCourt, Isaac Chansky, Michelle Bernstein, Alec Danaher, Sasha Maryl, Drew Love, Liani Lye, Andrew Cunningham, Liam Morley, Nick Francisci, Stephen Chin, Shameek Poddar, Will McIntosh, Andrew Seeder, Ben Lewis, Don Blair, Ethan Strominger, Nick Lee, Jonathan Marcus, Emily Wasserman, Ethan Blackwood,`,
     whoMadeThis3And:       ` und `,
     whoMadeThis3FinalName: `Valerie Kenyon`,
     whoMadeThisPeriod:     `.`,


### PR DESCRIPTION
Question: Should form-specific heading things be moved to a
different directory? A file in the 'forms' folder? I know we're
not using `ContentH1` anywhere other than forms right now, but
I hope to use it in the About page and maybe in our style guide,
other documentation, etc.