### PR TITLE
Interpolate snippets on demand

### DIFF
--- a/src/localization/all.js
+++ b/src/localization/all.js
@@ -1,8 +1,5 @@
 /** Contains and exports all the languages */
 
-import { interpolateSnippets } from '../utils/interpolation';
-import inlineComponents from './inlineComponents';
-
 import DE from './de';
 import EN from './en';
 import ZH from './zh';
@@ -12,11 +9,5 @@ var localizations = {
   en: EN,
   zh: ZH,
 };
-
-// Interpolate inline Components
-for (const lang in localizations) {
-  var snippets = localizations[ lang ];
-  localizations[ lang ] = interpolateSnippets(snippets, inlineComponents);
-}
 
 export { localizations };

--- a/src/localization/de.js
+++ b/src/localization/de.js
@@ -64,8 +64,8 @@ export default {
     whoMadeThis2C: ` aufrecht. Für weitere Auskunft treten Sie bitte in Verbindung mit `,
     whoMadeThis2D: `.`,
     
-    whoMadeThis3Intro: `Wir möchten den folgenden Freiwilligen von Code for Boston besonders danken: `,
-    whoMadeThis3Names: `Annie LaCourt, Isaac Chansky, Michelle Bernstein, Alec Danaher, Sasha Maryl, Drew Love, Liani Lye, Andrew Cunningham, Liam Morley, Nick Francisci, Stephen Chin, Shameek Poddar, Will McIntosh, Andrew Seeder, Ben Lewis, Don Blair, Ethan Strominger, Nick Lee, Jonathan Marcus, Emily Wasserman, Ethan Blackwood,`,
+    whoMadeThis3Intro:     `Wir möchten den folgenden Freiwilligen von Code for Boston besonders danken: `,
+    whoMadeThis3Names:     `Annie LaCourt, Isaac Chansky, Michelle Bernstein, Alec Danaher, Sasha Maryl, Drew Love, Liani Lye, Andrew Cunningham, Liam Morley, Nick Francisci, Stephen Chin, Shameek Poddar, Will McIntosh, Andrew Seeder, Ben Lewis, Don Blair, Ethan Strominger, Nick Lee, Jonathan Marcus, Emily Wasserman, Ethan Blackwood,`,
     whoMadeThis3And:       ` und `,
     whoMadeThis3FinalName: `Valerie Kenyon`,
     whoMadeThisPeriod:     `.`,

--- a/src/utils/getTextForLanguage.js
+++ b/src/utils/getTextForLanguage.js
@@ -1,8 +1,12 @@
 /** Returns a translator based on the language given */
+
+// TRANSFORMER FUNCTIONS
 import { mergeWith } from 'lodash';
+import { interpolateSnippets } from './interpolation.js';
 
 // DATA
 import { localizations } from '../localization/all';
+import inlineComponents from '../localization/inlineComponents';
 const english = localizations.en;  // unforunately, we need a default language
 
 /** Customizes Lodash's mergeWith function to replace arrays completely
@@ -21,18 +25,21 @@ const mergeCustomizer = function (objValue, srcValue) {
  */
 const getTextForLanguage = function (langName) {
 
+  let snippetsTemplate;
   if (localizations[ langName ]) {
 
     // deeply merge the object containing snippets in langName with English,
     // so that we fall back to English if a particular field is missing.
-    return mergeWith({}, english, localizations[ langName ], mergeCustomizer);
+    snippetsTemplate = mergeWith({}, english, localizations[ langName ], mergeCustomizer);
 
   } else {
 
     console.warn('There\'s no localization for ' + langName + '. Defaulting to English.');
-    return english;
+    snippetsTemplate = english;
 
   }
+
+  return interpolateSnippets(snippetsTemplate, inlineComponents);
 
 };  // End getTextForLanguage()
 


### PR DESCRIPTION
Fixes #673. I realized that we're already using a function to retrieve the snippets of a given language, so I just moved the interpolation step to happen within that function, after merging the snippets with the English ones to fill in any gaps.