### PR TITLE
 Fix language codes not actually specific to snippets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import { getTextForLanguage } from './utils/getTextForLanguage';
 class App extends Component {
   constructor (props) {
     super(props);
-    this.state = { language: 'de', snippets: getTextForLanguage('de') };
+    this.state = { language: 'en', snippets: getTextForLanguage('en') };
   }
 
   setLanguage = (inputProps) => {

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import { getTextForLanguage } from './utils/getTextForLanguage';
 class App extends Component {
   constructor (props) {
     super(props);
-    this.state = { language: 'en', snippets: getTextForLanguage('en') };
+    this.state = { language: 'de', snippets: getTextForLanguage('de') };
   }
 
   setLanguage = (inputProps) => {
@@ -30,7 +30,7 @@ class App extends Component {
   };
 
   render () {
-    var { snippets } = this.state;
+    var { language, snippets } = this.state;
 
     // Confirms user navigation
     var confirmer = new Confirmer();
@@ -38,7 +38,7 @@ class App extends Component {
     return (
       <div id='App'>
         <Helmet>
-          <html lang={ snippets.langCode } />
+          <html lang={ language } />
         </Helmet>
 
         <HashRouter getUserConfirmation={ confirmer.getConfirmation }>

--- a/src/utils/getTextForLanguage.js
+++ b/src/utils/getTextForLanguage.js
@@ -7,7 +7,9 @@ import { interpolateSnippets } from './interpolation.js';
 // DATA
 import { localizations } from '../localization/all';
 import inlineComponents from '../localization/inlineComponents';
-const english = localizations.en;  // unforunately, we need a default language
+
+// interpolate components into English snippets:
+const interpolatedEnglish = interpolateSnippets(localizations.en, inlineComponents);
 
 /** Customizes Lodash's mergeWith function to replace arrays completely
  * (to avoid arrays of English strings being mixed with arrays of translated
@@ -24,23 +26,20 @@ const mergeCustomizer = function (objValue, srcValue) {
  * doesn't exist, it warns the coder and returns English.
  */
 const getTextForLanguage = function (langName) {
+  if (langName === 'en') {
+    return interpolatedEnglish;
 
-  let snippetsTemplate;
-  if (localizations[ langName ]) {
-
+  } else if (localizations[ langName ]) {
+    const interpolatedSnippets = interpolateSnippets(localizations[ langName ], inlineComponents);
+    
     // deeply merge the object containing snippets in langName with English,
     // so that we fall back to English if a particular field is missing.
-    snippetsTemplate = mergeWith({}, english, localizations[ langName ], mergeCustomizer);
+    return mergeWith({}, interpolatedEnglish, interpolatedSnippets, mergeCustomizer);
 
   } else {
-
     console.warn('There\'s no localization for ' + langName + '. Defaulting to English.');
-    snippetsTemplate = english;
-
+    return interpolatedEnglish;
   }
-
-  return interpolateSnippets(snippetsTemplate, inlineComponents);
-
 };  // End getTextForLanguage()
 
 

--- a/src/utils/interpolation.js
+++ b/src/utils/interpolation.js
@@ -38,7 +38,7 @@ const interpolateText = function (template, components, langCode) {
 
 /** Recursively interpolate each template in a snippets object */
 const interpolateSnippets = function (snippets, components) {
-  return mapValues(snippets, (value) => {
+  return mapValues(snippets, (value, key) => {
 
     count++;
     var langCode = snippets.langCode;
@@ -48,7 +48,10 @@ const interpolateSnippets = function (snippets, components) {
       lang: langCode,
     };
 
-    if (typeof(value) === 'string') {
+    if (key === 'langCode') {
+      // don't wrap the langCode, it's just metadata
+      return value;
+    } else if (typeof(value) === 'string') {
       // plain translated string
       return (<span { ...props }>{ value }</span>);
     } else if (Array.isArray(value)) {
@@ -59,7 +62,7 @@ const interpolateSnippets = function (snippets, components) {
       value.langCode = langCode;
       return interpolateSnippets(value, components);
     }
-    
+
   });
 };
 


### PR DESCRIPTION
Fixes #678. Interpolates snippet objects _before_ merging them, so that the spans created from the snippets in each object get the correct `lang` code during the interpolation process. You can see the change by setting the default language in `App.js` to `de` instead of `en`, and comparing snippets that are already in German with those that are currently defaulted to English.

I also noticed that the `<html>` tag had an invalid `lang` attribute (`[object Object]`), since the `langCode` was also getting wrapped in a `<span>`. I changed the interpolation function to not wrap `langCode`, but just to be doubly safe, I also changed the `<html>` attribute to use the language code from the state directly rather than reading from the snippets.