### PR TITLE
Cache interpolated/merged snippets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import { getTextForLanguage } from './utils/getTextForLanguage';
 class App extends Component {
   constructor (props) {
     super(props);
-    this.state = { language: 'en', snippets: getTextForLanguage('en') };
+    this.state = { langCode: 'en', snippets: getTextForLanguage('en') };
   }
 
   setLanguage = (inputProps) => {
@@ -30,7 +30,7 @@ class App extends Component {
   };
 
   render () {
-    var { language, snippets } = this.state;
+    var { langCode, snippets } = this.state;
 
     // Confirms user navigation
     var confirmer = new Confirmer();
@@ -38,7 +38,7 @@ class App extends Component {
     return (
       <div id='App'>
         <Helmet>
-          <html lang={ language } />
+          <html lang={ langCode } />
         </Helmet>
 
         <HashRouter getUserConfirmation={ confirmer.getConfirmation }>


### PR DESCRIPTION
On top of the method for fixing #678 in #679. In that PR, the interpolated English snippets are calculated beforehand and kept as part of the `getTextForLanguage` function (in its closure). This goes further by keeping an object in that function's closure which contains the English snippets as well as all other interpolated and merged snippets that have been calculated so far - basically it caches its output. So `getTextForLanguage` doesn't have to call `interpolateSnippets` or `mergeWith` again if it is called a second time for a given language.

(I played around with inspecting `finishedSnippets` using a breakpoint in Chrome dev tools while changing the language, and it seems to be working correctly (that being said we should write some tests for this file!))