### PR TITLE
Fix StepBar titles - #693

### DIFF
--- a/src/components/StepBar.js
+++ b/src/components/StepBar.js
@@ -6,10 +6,10 @@ const StepBar = ({ steps, currentStepIndex, goToStep, snippets }) => {
   var cleanSteps = [];
 
   steps.forEach((step, index) => {
-    var newStep = { title: snippets[ step.key ] };
+    var newStep = { title: { content: snippets[ step.key ] }};
     newStep.active = index === (currentStepIndex - 1);
     newStep.onClick = (e) => {
-      goToStep(index + 1); 
+      goToStep(index + 1);
     };
     newStep.key = index;
     cleanSteps[ index ] = newStep;


### PR DESCRIPTION
Fixes #693. The issue was that `snippets[ step.key ]` is now a `<span>` with a `lang` attribute rather than just a string, and that meant the Semantic UI React shorthand for the titles had to be tweaked a little.