### PR TITLE
Add maximum value limit to input boxes

### DIFF
--- a/.buildconfig
+++ b/.buildconfig
@@ -1,0 +1,10 @@
+[default]
+name=Default
+runtime=host
+config-opts=
+run-opts=
+prefix=/home/jason/.cache/gnome-builder/install/forms/host
+app-id=
+postbuild=
+prebuild=
+default=true

--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -253,7 +253,8 @@ const MemberField = function ({ household, time, setHousehold, updateClientValue
           storeValidator   = { isNonNegWholeNumber }
           format           = { function (value) { return value; } }
           store            = { onMemberChange }
-          onBlur           = { function () { return true; } } />
+          onBlur           = { function () { return true; } }
+          maximum          = { 999 } />
       </Columns.Three>
 
       <Columns.Four>

--- a/src/forms/cashflow.js
+++ b/src/forms/cashflow.js
@@ -91,15 +91,18 @@ const CashFlowRow = function ({ generic, timeState, updateClientValue, children 
       <ManagedNumberField
         { ...baseProps }
         value     = { baseVal / (4 + 1 / 3) }
-        otherData = {{ interval: 'weekly' }} />
+        otherData = {{ interval: 'weekly' }} 
+        maximum   = { 19230.76 } />
       <ManagedNumberField
         { ...baseProps }
         value     = { baseVal }
-        otherData = {{ interval: 'monthly' }} />
+        otherData = {{ interval: 'monthly' }}
+        maximum   = { 83333.33 } />
       <ManagedNumberField
         { ...baseProps }
         value     = { baseVal * 12 }
-        otherData = {{ interval: 'yearly' }} />
+        otherData = {{ interval: 'yearly' }}
+        maximum   = { 999999.99 } />
     </CashFlowContainer>
   );
 

--- a/src/forms/inputs.js
+++ b/src/forms/inputs.js
@@ -131,7 +131,7 @@ class ManagedNumberField extends Component {
   };
 
   handleChange = (evnt, inputProps) => {
-    var { displayValidator, storeValidator, store, otherData } = this.props;
+    var { displayValidator, storeValidator, store, otherData, maximum } = this.props;
     var focusedVal = inputProps.value;
 
     // If doesn't pass display validator, don't store and don't change focusedVal
@@ -143,6 +143,14 @@ class ManagedNumberField extends Component {
       // If field contains an empty string, set value to be 0 (visible on blur)
       inputProps.value = '0';
     }
+
+    if(maximum) {
+      // Enforce maximum value
+      if (Boolean(parseFloat(focusedVal)) && focusedVal > maximum) {
+        inputProps.value = maximum;
+      }
+    }
+
     var valid = storeValidator(inputProps.value);
 
     if (valid) {
@@ -152,14 +160,21 @@ class ManagedNumberField extends Component {
   };  // End handleChange()
 
   render() {
-    var { valid, focused, focusedVal }      = this.state;
-    var { value, name, className, format }  = this.props;
+    var { valid, focused, focusedVal }              = this.state;
+    var { value, name, className, format, maximum } = this.props;
 
     // Format correctly when neighbors are updated, if needed
     if (!focused) {
       value = format(value);
     } else {
       value = focusedVal;
+    }
+
+    if(maximum) {
+      // Enforce maximum value
+      if (Boolean(value) && value > maximum) {
+        value = maximum;
+      }
     }
 
     /** @todo Different class for something 'future' that has a current value that isn't 0 */


### PR DESCRIPTION
Add a maximum limit of $999999.99 of yearly income/spending to the input boxes, because values over 1 million do not fit in the text box. Also imposes a maximum of 999 for household member age for sanity.

The maximum is accordingly set to $19230.76 for weekly income/spending, and $83333.33 for monthly. However, when setting the weekly and monthly income or spending to these values, the yearly income will come up a few cents below the maximum. This is just a minor annoyance, though.