### PR TITLE
 Update English localization in about section to latest value in Google Docs

### DIFF
--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -41,7 +41,7 @@ export default {
 
     whyHeader: `Why is this tool important?`,
     why1:      `A cliff effect occurs when a slight change in a household’s circumstances - say, a slight pay raise - disproportionately lowers their benefits. The household is working to increase what they earn, but they end up with a net loss that actually puts them further behind. These cliff effects prevent many families from actually getting off of public assistance programs.`,
-    why2:      `Cliff effects are also difficult to predict. The interactions between income, household s impact each other in unexpected ways. We're exploring ways to deal with this issue of complexity and help families better understand and predict their situation.`,
+    why2:      `Cliff effects are also difficult to predict. The interactions between income, household size, many other criteria, as well as the effects of the programs themselves impact each other in unexpected ways. We're exploring ways to deal with this issue of complexity and help families better understand and predict their situation.`,
 
     videoLinkText:    `Two-minute video describing cliff effects`,
     quantLinkText:    `Quantitative scenarios demonstrating cliff effects`,


### PR DESCRIPTION
Simply updates one localization line to fix the typo in #690.