### PR TITLE
Change component of Route to a function to elminiate warning

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,16 +95,17 @@ class App extends Component {
                     confirmer = { confirmer }
                     snippets  = {{ ...snippets.visitPage, langCode: snippets.langCode }} />);
               } } />
-              
+
             {/* Currently only works on published build */}
             <Route
               path="/docs"
-              component={
-                <iframe
-                  id="docsFrame"
-                  title="Cliff Effects Docs"
-                  src="/docs/index.html" />
-              } />
+              component={ () => {
+                return (
+                  <iframe
+                    id="docsFrame"
+                    title="Cliff Effects Docs"
+                    src="/docs/index.html" />);
+              } } />
           </div>
         </HashRouter>
         <Footer snippets={{ ...snippets.footer, langCode: snippets.langCode }} />


### PR DESCRIPTION
There was a warning for the `/docs` route  saying that its `component` prop should be a function rather than an object. This makes it into a function.