### PR TITLE
Add jsx indentation eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,8 @@
     "react/jsx-closing-tag-location": ["warn"],
     "react/jsx-curly-spacing": ["warn", "always", { "spacing": { "objectLiterals": "never" }}],
     "react/jsx-first-prop-new-line": ["warn", "multiline-multiprop"],
+    "react/jsx-indent": ["warn", 2],
+    "react/jsx-indent-props": ["warn", 2],
     "react/jsx-max-props-per-line": ["warn", { "maximum": 1 }],
     "react/jsx-tag-spacing": ["warn"],
     "react/self-closing-comp": "warn",

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   HashRouter,
   Route,
-  Switch
+  Switch,
 } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 

--- a/src/components/prompts/FeedbackForm.js
+++ b/src/components/prompts/FeedbackForm.js
@@ -21,8 +21,13 @@ class FeedbackPrompt extends React.Component {
   handleInputChange = (event) => {
     // Source: https://reactjs.org/docs/forms.html#controlled-components
     const target = event.target;
-    const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
+    let value;
+    if (target.type === 'checkbox') {
+      value = target.checked;
+    } else {
+      value = target.value;
+    }
 
     this.setState({ formData: Object.assign({}, this.state.formData, { [ name ]: value }) });
   };

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -141,7 +141,7 @@ class VisitPage extends Component {
 
   askForFeedback = (callback, promptText) => {
 
-    // When user exits feedback prompt somehow, 
+    // When user exits feedback prompt somehow,
     // close it before finishing the callback.
     var closePrompt = (isOk) => {
       this.setState({ promptData: { open: false }});
@@ -371,10 +371,11 @@ class VisitPage extends Component {
          * do this we might do this a different way at this
          * point. Perhaps a user's page should be a route
          * in VisitPage? Like our form sections will be? */}
-        {this.state.redirect ?
-          <Redirect to={ `/detail/${this.state.clientInfo.clientId}` } /> :
+        { this.state.redirect ? (
+          <Redirect to={ `/detail/${this.state.clientInfo.clientId}` } />
+        ) : (
           false
-        }
+        ) }
 
         {/* = SECTION = */}
         {/* `padding` here duplicates previous `<Grid>` styleing */}

--- a/src/forms/CurrentExpenses.js
+++ b/src/forms/CurrentExpenses.js
@@ -220,11 +220,10 @@ const Housing = function ({ current, type, time, updateClientValue }) {
 
       <ContentH1>Housing</ContentH1>
 
-      { current.housing === 'voucher'
-        ? null
-        :
+      { current.housing === 'voucher' ? (
+        null
+      ) : (
         <div>
-
           <Header as='h4'>What is your housing situation?</Header>
           <HousingRadio
             currentValue={ current.housing }
@@ -241,8 +240,8 @@ const Housing = function ({ current, type, time, updateClientValue }) {
             label={ 'Homeowner' }
             time={ time }
             updateClientValue = { ensureRouteAndValue } />
-
-        </div>}
+        </div>
+      ) }
 
       <HousingDetails { ...sharedProps } />
 
@@ -294,158 +293,153 @@ const ExpensesFormContent = function ({ current, time, updateClientValue, snippe
   return (
     <div className='field-aligner two-column'>
 
-      { under13.length > 0
-        ? (
-          <div>
-            <ContentH1 subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
-              { snippets.unreimbursedNonMedicalChildCare.sectionHeading }
-            </ContentH1>
-            <IntervalColumnHeadings type={ type } />
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'childDirectCare' }>
-              { snippets.unreimbursedNonMedicalChildCare.childDirectCare.label }
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'childBeforeAndAfterSchoolCare' }>
-              { snippets.unreimbursedNonMedicalChildCare.childBeforeAndAfterSchoolCare.label}
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'childTransportation' }>
-              { snippets.unreimbursedNonMedicalChildCare.childTransportation.label }
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'childOtherCare' }>
-              { snippets.unreimbursedNonMedicalChildCare.childOtherCare.label }
-            </CashFlowInputsRow>
+      { under13.length > 0 ? (
+        <div>
+          <ContentH1 subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
+            { snippets.unreimbursedNonMedicalChildCare.sectionHeading }
+          </ContentH1>
+          <IntervalColumnHeadings type={ type } />
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'childDirectCare' }>
+            { snippets.unreimbursedNonMedicalChildCare.childDirectCare.label }
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'childBeforeAndAfterSchoolCare' }>
+            { snippets.unreimbursedNonMedicalChildCare.childBeforeAndAfterSchoolCare.label}
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'childTransportation' }>
+            { snippets.unreimbursedNonMedicalChildCare.childTransportation.label }
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'childOtherCare' }>
+            { snippets.unreimbursedNonMedicalChildCare.childOtherCare.label }
+          </CashFlowInputsRow>
 
-            <EarnedFrom
-              hasExpenses   ={ getUnder13Expenses(current) !== 0 }
-              cashflowProps ={{
-                ...sharedProps,
-                generic:      'earnedBecauseOfChildCare',
-                confirmLabel: `If you didn't have that child care, would it change how much pay you can bring home?`,
-              }}>
-              How much less would you make?
-            </EarnedFrom>
-          </div>
-        )
-        : null
-      }
+          <EarnedFrom
+            hasExpenses   ={ getUnder13Expenses(current) !== 0 }
+            cashflowProps ={{
+              ...sharedProps,
+              generic:      'earnedBecauseOfChildCare',
+              confirmLabel: `If you didn't have that child care, would it change how much pay you can bring home?`,
+            }}>
+            How much less would you make?
+          </EarnedFrom>
+        </div>
+      ) : (
+        null
+      ) }
 
-      { current.hasSnap
-        ? (
-          <div>
-            <ContentH1>Child Support</ContentH1>
-            <IntervalColumnHeadings type={ type } />
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'childSupportPaidOut' }> <strong>Legally obligated</strong> child support
-            </CashFlowInputsRow>
-          </div>
-        )
-        : null
-      }
+      { current.hasSnap ? (
+        <div>
+          <ContentH1>Child Support</ContentH1>
+          <IntervalColumnHeadings type={ type } />
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'childSupportPaidOut' }> <strong>Legally obligated</strong> child support
+          </CashFlowInputsRow>
+        </div>
+      ) : (
+        null
+      ) }
 
       {/* Head or spouse can't be a dependent, so they don't count. */}
-      { over12.length > 0
-        ? (
-          <div>
-            <ContentH1 subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
-              Dependent Care of Persons Over 12 Years of Age
-            </ContentH1>
-            <IntervalColumnHeadings type={ type } />
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'adultDirectCare' }> Direct care costs
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'adultTransportation' }> Transportation costs
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'adultOtherCare' }> Other care
-            </CashFlowInputsRow>
-          </div>
-        )
-        : null
-      }
+      { over12.length > 0 ? (
+        <div>
+          <ContentH1 subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
+            Dependent Care of Persons Over 12 Years of Age
+          </ContentH1>
+          <IntervalColumnHeadings type={ type } />
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'adultDirectCare' }> Direct care costs
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'adultTransportation' }> Transportation costs
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'adultOtherCare' }> Other care
+          </CashFlowInputsRow>
+        </div>
+      ) : (
+        null
+      ) }
 
-      { elderlyOrDisabled.length > 0
-        ? (
-          <div>
-            <HeadingWithDetail>
-              <ContentH1>Unreimbursed Disabled/Handicapped/Elderly Assistance</ContentH1>
-              <div>
-                <div>Unreimbursed expenses to cover care attendants and auxiliary apparatus for any family member who is elderly or is a person with disabilities. Auxiliary apparatus are items such as wheelchairs, ramps, adaptations to vehicles, or special equipment to enable a blind person to read or type, but only if these items are directly related to permitting the disabled person or other family member to work.</div>
-                <div>Examples of eligible disability assistance expenses:</div>
-                <ul>
-                  <li>The payments made on a motorized wheelchair for the 42 year old son of the head of household enable the son to leave the house and go to work each day on his own. Prior to the purchase of the motorized wheelchair, the son was unable to make the commute to work. These payments are an eligible disability assistance expense.</li>
-                  <li>Payments to a care attendant to stay with a disabled 16-year-old child allow the child’s mother to go to work every day. These payments are an eligible disability assistance allowance.</li>
-                </ul>
-              </div>
-            </HeadingWithDetail>
-            <IntervalColumnHeadings type={ type } />
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic={ 'disabledAssistance' }> Disabled/Handicapped assistance
-            </CashFlowInputsRow>
+      { elderlyOrDisabled.length > 0 ? (
+        <div>
+          <HeadingWithDetail>
+            <ContentH1>Unreimbursed Disabled/Handicapped/Elderly Assistance</ContentH1>
+            <div>
+              <div>Unreimbursed expenses to cover care attendants and auxiliary apparatus for any family member who is elderly or is a person with disabilities. Auxiliary apparatus are items such as wheelchairs, ramps, adaptations to vehicles, or special equipment to enable a blind person to read or type, but only if these items are directly related to permitting the disabled person or other family member to work.</div>
+              <div>Examples of eligible disability assistance expenses:</div>
+              <ul>
+                <li>The payments made on a motorized wheelchair for the 42 year old son of the head of household enable the son to leave the house and go to work each day on his own. Prior to the purchase of the motorized wheelchair, the son was unable to make the commute to work. These payments are an eligible disability assistance expense.</li>
+                <li>Payments to a care attendant to stay with a disabled 16-year-old child allow the child’s mother to go to work every day. These payments are an eligible disability assistance allowance.</li>
+              </ul>
+            </div>
+          </HeadingWithDetail>
+          <IntervalColumnHeadings type={ type } />
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic={ 'disabledAssistance' }> Disabled/Handicapped assistance
+          </CashFlowInputsRow>
 
-            <EarnedFrom
-              hasExpenses   ={ current.disabledAssistance !== 0 }
-              cashflowProps ={{
-                ...sharedProps,
-                generic:      'earnedBecauseOfAdultCare',
-                confirmLabel: `If you didn't have that assistance, would it change how much pay you can bring home?`,
-              }}>
-            How much less would you make?
-            </EarnedFrom>
-          </div>
-        )
-        : null
-      }
+          <EarnedFrom
+            hasExpenses   ={ current.disabledAssistance !== 0 }
+            cashflowProps ={{
+              ...sharedProps,
+              generic:      'earnedBecauseOfAdultCare',
+              confirmLabel: `If you didn't have that assistance, would it change how much pay you can bring home?`,
+            }}>
+          How much less would you make?
+          </EarnedFrom>
+        </div>
+      ) : (
+        null
+      ) }
 
       {/** These medical expenses don't count for Section 8 unless
         *     the disabled person is the head or spouse. From
         *     {@link http://www.tacinc.org/media/58886/S8MS%20Full%20Book.pdf}
         *     Appendix B, item (D) */}
-      { elderlyOrDisabledHeadOrSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0)
-        ? (
-          <div>
-            <HeadingWithDetail>
-              <ContentH1>Unreimbursed Medical Expenses</ContentH1>
-              <div>
-                <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
-                <ul>
-                  <li>The orthodontist expenses for a child’s braces.</li>
-                  <li>Services of doctors and health care professionals.</li>
-                  <li>Services of health care facilities.</li>
-                  <li>Medical insurance premiums. </li>
-                  <li>Prescription/non-prescription medicines (prescribed by a physician).</li>
-                  <li>Transportation to treatment (cab fare, bus fare, mileage).</li>
-                  <li>Dental expenses, eyeglasses, hearing aids, batteries.</li>
-                  <li>Live-in or periodic medical assistance.</li>
-                  <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred).</li>
-                </ul>
-              </div>
-            </HeadingWithDetail>
-            <IntervalColumnHeadings type={ type } />
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic='disabledMedical'> Disabled/Elderly medical expenses
-            </CashFlowInputsRow>
-            <CashFlowInputsRow
-              { ...sharedProps }
-              generic='otherMedical'> Medical expenses of other members
-            </CashFlowInputsRow>
-          </div>
-        )
-        : null
-      }
+      { elderlyOrDisabledHeadOrSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0) ? (
+        <div>
+          <HeadingWithDetail>
+            <ContentH1>Unreimbursed Medical Expenses</ContentH1>
+            <div>
+              <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
+              <ul>
+                <li>The orthodontist expenses for a child’s braces.</li>
+                <li>Services of doctors and health care professionals.</li>
+                <li>Services of health care facilities.</li>
+                <li>Medical insurance premiums. </li>
+                <li>Prescription/non-prescription medicines (prescribed by a physician).</li>
+                <li>Transportation to treatment (cab fare, bus fare, mileage).</li>
+                <li>Dental expenses, eyeglasses, hearing aids, batteries.</li>
+                <li>Live-in or periodic medical assistance.</li>
+                <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred).</li>
+              </ul>
+            </div>
+          </HeadingWithDetail>
+          <IntervalColumnHeadings type={ type } />
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic='disabledMedical'> Disabled/Elderly medical expenses
+          </CashFlowInputsRow>
+          <CashFlowInputsRow
+            { ...sharedProps }
+            generic='otherMedical'> Medical expenses of other members
+          </CashFlowInputsRow>
+        </div>
+      ) : (
+        null
+      ) }
 
       <Housing
         current={ current }

--- a/src/forms/CurrentExpenses.js
+++ b/src/forms/CurrentExpenses.js
@@ -151,15 +151,15 @@ const HousingDetails = function ({ current, type, time, updateClientValue }) {
         <IntervalColumnHeadings type={ type } />
         <CashFlowInputsRow
           { ...sharedProps }
-          generic={ 'mortgage' }> Mortgage 
+          generic={ 'mortgage' }> Mortgage
         </CashFlowInputsRow>
         <CashFlowInputsRow
           { ...sharedProps }
-          generic={ 'housingInsurance' }> Insurance Costs 
+          generic={ 'housingInsurance' }> Insurance Costs
         </CashFlowInputsRow>
         <CashFlowInputsRow
           { ...sharedProps }
-          generic={ 'propertyTax' }> Property Tax 
+          generic={ 'propertyTax' }> Property Tax
         </CashFlowInputsRow>
         <Utilities { ...sharedProps } />
       </div>
@@ -187,14 +187,14 @@ const HousingRadio = function ({ currentValue, label, time, updateClientValue })
 };  // End HousingRadio(<>)
 
 
-/** 
+/**
  * @function
  * @param {object} props
  * @param {object} props.current - Client data of current user circumstances
  * @param {string} props.type - 'expense' or 'income', etc., for classes
  * @param {string} props.time - 'current' or 'future'
  * @param {function} props.updateClientValue - Sets state values
- * 
+ *
  * @returns React element
  */
 const Housing = function ({ current, type, time, updateClientValue }) {
@@ -222,9 +222,9 @@ const Housing = function ({ current, type, time, updateClientValue }) {
 
       { current.housing === 'voucher'
         ? null
-        : 
+        :
         <div>
-          
+
           <Header as='h4'>What is your housing situation?</Header>
           <HousingRadio
             currentValue={ current.housing }
@@ -252,13 +252,13 @@ const Housing = function ({ current, type, time, updateClientValue }) {
 };  // End Housing()
 
 
-/** 
+/**
  * @function
  * @param {object} props
  * @param {object} props.current - Client data of current user circumstances
  * @param {object} props.time - 'current' or 'future'
  * @param {object} props.updateClientValue - Sets state values
- * 
+ *
  * @returns React element
  */
 const ExpensesFormContent = function ({ current, time, updateClientValue, snippets }) {
@@ -273,9 +273,9 @@ const ExpensesFormContent = function ({ current, time, updateClientValue, snippe
       };
 
   /** @todo Make an age-checking function to
-   *     keep household data structure under 
+   *     keep household data structure under
    *     control in one place. */
-  var isOver12 = function (member) { 
+  var isOver12 = function (member) {
     return !isUnder13(member);
   };
 
@@ -295,151 +295,155 @@ const ExpensesFormContent = function ({ current, time, updateClientValue, snippe
     <div className='field-aligner two-column'>
 
       { under13.length > 0
-        ? 
-        <div>
-          <ContentH1 subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
-            { snippets.unreimbursedNonMedicalChildCare.sectionHeading }
-          </ContentH1>
-          <IntervalColumnHeadings type={ type } />
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'childDirectCare' }> 
-            { snippets.unreimbursedNonMedicalChildCare.childDirectCare.label }
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'childBeforeAndAfterSchoolCare' }>
-            { snippets.unreimbursedNonMedicalChildCare.childBeforeAndAfterSchoolCare.label}
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'childTransportation' }> 
-            { snippets.unreimbursedNonMedicalChildCare.childTransportation.label }
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'childOtherCare' }> 
-            { snippets.unreimbursedNonMedicalChildCare.childOtherCare.label }
-          </CashFlowInputsRow>
+        ? (
+          <div>
+            <ContentH1 subheading = { snippets.unreimbursedNonMedicalChildCare.subheading }>
+              { snippets.unreimbursedNonMedicalChildCare.sectionHeading }
+            </ContentH1>
+            <IntervalColumnHeadings type={ type } />
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'childDirectCare' }>
+              { snippets.unreimbursedNonMedicalChildCare.childDirectCare.label }
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'childBeforeAndAfterSchoolCare' }>
+              { snippets.unreimbursedNonMedicalChildCare.childBeforeAndAfterSchoolCare.label}
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'childTransportation' }>
+              { snippets.unreimbursedNonMedicalChildCare.childTransportation.label }
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'childOtherCare' }>
+              { snippets.unreimbursedNonMedicalChildCare.childOtherCare.label }
+            </CashFlowInputsRow>
 
-          <EarnedFrom
-            hasExpenses   ={ getUnder13Expenses(current) !== 0 }
-            cashflowProps ={{
-              ...sharedProps,
-              generic:      'earnedBecauseOfChildCare',
-              confirmLabel: `If you didn't have that child care, would it change how much pay you can bring home?`,
-            }}>
-            How much less would you make?
-          </EarnedFrom>
-        </div>
+            <EarnedFrom
+              hasExpenses   ={ getUnder13Expenses(current) !== 0 }
+              cashflowProps ={{
+                ...sharedProps,
+                generic:      'earnedBecauseOfChildCare',
+                confirmLabel: `If you didn't have that child care, would it change how much pay you can bring home?`,
+              }}>
+              How much less would you make?
+            </EarnedFrom>
+          </div>
+        )
         : null
       }
 
       { current.hasSnap
-        ? 
-        <div>
-          <ContentH1>Child Support</ContentH1>
-          <IntervalColumnHeadings type={ type } />
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'childSupportPaidOut' }> <strong>Legally obligated</strong> child support 
-          </CashFlowInputsRow>
-        </div>
+        ? (
+          <div>
+            <ContentH1>Child Support</ContentH1>
+            <IntervalColumnHeadings type={ type } />
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'childSupportPaidOut' }> <strong>Legally obligated</strong> child support
+            </CashFlowInputsRow>
+          </div>
+        )
         : null
       }
 
       {/* Head or spouse can't be a dependent, so they don't count. */}
       { over12.length > 0
-        ? 
-        <div>
-          <ContentH1 subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
-            Dependent Care of Persons Over 12 Years of Age
-          </ContentH1>
-          <IntervalColumnHeadings type={ type } />
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'adultDirectCare' }> Direct care costs 
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'adultTransportation' }> Transportation costs 
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'adultOtherCare' }> Other care 
-          </CashFlowInputsRow>
-        </div>
+        ? (
+          <div>
+            <ContentH1 subheading = { 'For the care of people who are older than 12, but are still dependents (those under 18 or disabled). Don\'t include amounts that are paid for by other benefit programs.\n' }>
+              Dependent Care of Persons Over 12 Years of Age
+            </ContentH1>
+            <IntervalColumnHeadings type={ type } />
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'adultDirectCare' }> Direct care costs
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'adultTransportation' }> Transportation costs
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'adultOtherCare' }> Other care
+            </CashFlowInputsRow>
+          </div>
+        )
         : null
       }
 
       { elderlyOrDisabled.length > 0
-        ? 
-        <div>
-          <HeadingWithDetail>
-            <ContentH1>Unreimbursed Disabled/Handicapped/Elderly Assistance</ContentH1>
-            <div>
-              <div>Unreimbursed expenses to cover care attendants and auxiliary apparatus for any family member who is elderly or is a person with disabilities. Auxiliary apparatus are items such as wheelchairs, ramps, adaptations to vehicles, or special equipment to enable a blind person to read or type, but only if these items are directly related to permitting the disabled person or other family member to work.</div>
-              <div>Examples of eligible disability assistance expenses:</div>
-              <ul>
-                <li>The payments made on a motorized wheelchair for the 42 year old son of the head of household enable the son to leave the house and go to work each day on his own. Prior to the purchase of the motorized wheelchair, the son was unable to make the commute to work. These payments are an eligible disability assistance expense.</li>
-                <li>Payments to a care attendant to stay with a disabled 16-year-old child allow the child’s mother to go to work every day. These payments are an eligible disability assistance allowance.</li>
-              </ul>
-            </div>
-          </HeadingWithDetail>
-          <IntervalColumnHeadings type={ type } />
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic={ 'disabledAssistance' }> Disabled/Handicapped assistance 
-          </CashFlowInputsRow>
+        ? (
+          <div>
+            <HeadingWithDetail>
+              <ContentH1>Unreimbursed Disabled/Handicapped/Elderly Assistance</ContentH1>
+              <div>
+                <div>Unreimbursed expenses to cover care attendants and auxiliary apparatus for any family member who is elderly or is a person with disabilities. Auxiliary apparatus are items such as wheelchairs, ramps, adaptations to vehicles, or special equipment to enable a blind person to read or type, but only if these items are directly related to permitting the disabled person or other family member to work.</div>
+                <div>Examples of eligible disability assistance expenses:</div>
+                <ul>
+                  <li>The payments made on a motorized wheelchair for the 42 year old son of the head of household enable the son to leave the house and go to work each day on his own. Prior to the purchase of the motorized wheelchair, the son was unable to make the commute to work. These payments are an eligible disability assistance expense.</li>
+                  <li>Payments to a care attendant to stay with a disabled 16-year-old child allow the child’s mother to go to work every day. These payments are an eligible disability assistance allowance.</li>
+                </ul>
+              </div>
+            </HeadingWithDetail>
+            <IntervalColumnHeadings type={ type } />
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic={ 'disabledAssistance' }> Disabled/Handicapped assistance
+            </CashFlowInputsRow>
 
-          <EarnedFrom
-            hasExpenses   ={ current.disabledAssistance !== 0 }
-            cashflowProps ={{
-              ...sharedProps,
-              generic:      'earnedBecauseOfAdultCare',
-              confirmLabel: `If you didn't have that assistance, would it change how much pay you can bring home?`,
-            }}>
+            <EarnedFrom
+              hasExpenses   ={ current.disabledAssistance !== 0 }
+              cashflowProps ={{
+                ...sharedProps,
+                generic:      'earnedBecauseOfAdultCare',
+                confirmLabel: `If you didn't have that assistance, would it change how much pay you can bring home?`,
+              }}>
             How much less would you make?
-          </EarnedFrom>
-        </div>
+            </EarnedFrom>
+          </div>
+        )
         : null
       }
 
       {/** These medical expenses don't count for Section 8 unless
-        *     the disabled person is the head or spouse. From 
+        *     the disabled person is the head or spouse. From
         *     {@link http://www.tacinc.org/media/58886/S8MS%20Full%20Book.pdf}
         *     Appendix B, item (D) */}
       { elderlyOrDisabledHeadOrSpouse.length > 0 || (current.hasSnap && elderlyOrDisabled.length > 0)
-        ? 
-        <div>
-
-          <HeadingWithDetail>
-            <ContentH1>Unreimbursed Medical Expenses</ContentH1>
-            <div>
-              <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
-              <ul>
-                <li>The orthodontist expenses for a child’s braces.</li>
-                <li>Services of doctors and health care professionals.</li>
-                <li>Services of health care facilities.</li>
-                <li>Medical insurance premiums. </li>
-                <li>Prescription/non-prescription medicines (prescribed by a physician).</li>
-                <li>Transportation to treatment (cab fare, bus fare, mileage).</li>
-                <li>Dental expenses, eyeglasses, hearing aids, batteries.</li>
-                <li>Live-in or periodic medical assistance.</li>
-                <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred).</li>
-              </ul>
-            </div>
-          </HeadingWithDetail>
-          <IntervalColumnHeadings type={ type } />
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic='disabledMedical'> Disabled/Elderly medical expenses 
-          </CashFlowInputsRow>
-          <CashFlowInputsRow
-            { ...sharedProps }
-            generic='otherMedical'> Medical expenses of other members 
-          </CashFlowInputsRow>
-        </div>
+        ? (
+          <div>
+            <HeadingWithDetail>
+              <ContentH1>Unreimbursed Medical Expenses</ContentH1>
+              <div>
+                <div>Do not repeat anything you already listed in the section above. Examples of allowable medical expenses:</div>
+                <ul>
+                  <li>The orthodontist expenses for a child’s braces.</li>
+                  <li>Services of doctors and health care professionals.</li>
+                  <li>Services of health care facilities.</li>
+                  <li>Medical insurance premiums. </li>
+                  <li>Prescription/non-prescription medicines (prescribed by a physician).</li>
+                  <li>Transportation to treatment (cab fare, bus fare, mileage).</li>
+                  <li>Dental expenses, eyeglasses, hearing aids, batteries.</li>
+                  <li>Live-in or periodic medical assistance.</li>
+                  <li>Monthly payment on accumulated medical bills (regular monthly payments on a bill that was previously incurred).</li>
+                </ul>
+              </div>
+            </HeadingWithDetail>
+            <IntervalColumnHeadings type={ type } />
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic='disabledMedical'> Disabled/Elderly medical expenses
+            </CashFlowInputsRow>
+            <CashFlowInputsRow
+              { ...sharedProps }
+              generic='otherMedical'> Medical expenses of other members
+            </CashFlowInputsRow>
+          </div>
+        )
         : null
       }
 
@@ -474,14 +478,14 @@ const ExpensesFormContent = function ({ current, time, updateClientValue, snippe
  *     household member?
  */
 
-/** 
+/**
   * @function
   * @param {object} props
   * @param {function} props.updateClientValue - Setting client state
   * @param {function} props.previousStep - Go to previous form step
   * @param {function} props.nextStep - Go to next form step
   * @param {object} props.client - Object will all the data for calculating benefits
-  * 
+  *
   * @returns React element
   */
 // `props` is a cloned version of the original props. References broken.

--- a/src/forms/ExpensesOther.js
+++ b/src/forms/ExpensesOther.js
@@ -92,11 +92,11 @@ const ExpensesOther = function ({ timeState, type, time, updateClientValue }) {
       <CashFlowInputsRow
         { ...sharedProps }
         generic = { `otherExpensesTransport` }>
-        {
-          dependentTransport > 0 ?
-            `Money you spend on other transportation`
-            : `Money you spend on transportation`
-        }
+        { dependentTransport > 0 ? (
+          `Money you spend on other transportation`
+        ) : (
+          `Money you spend on transportation`
+        ) }
       </CashFlowInputsRow>
 
       <RenderIfTrue shouldRender = { medExpenses > 0 }>
@@ -112,15 +112,15 @@ const ExpensesOther = function ({ timeState, type, time, updateClientValue }) {
       <CashFlowInputsRow
         { ...sharedProps }
         generic = { `otherExpensesMedical` }>
-        {
-          medExpenses > 0 ?
-            `Money you spend because of other medical problems`
-            : `Money you spend because of medical problems`
-        }
+        { medExpenses > 0 ? (
+          `Money you spend because of other medical problems`
+        ) : (
+          `Money you spend because of medical problems`
+        ) }
       </CashFlowInputsRow>
       <CashFlowInputsRow
         { ...sharedProps }
-        generic={ `otherExpensesFood` }> Money you spend on food 
+        generic={ `otherExpensesFood` }> Money you spend on food
       </CashFlowInputsRow>
       {/* Utilities are complicated because the housing
       * voucher could be taking them into account and

--- a/src/forms/FormPartsContainer.js
+++ b/src/forms/FormPartsContainer.js
@@ -20,7 +20,7 @@ const SpaceHolder = function () {
 
 /** The row containing the big buttons at the bottom of each
 *     form section, such as 'Previous', 'Next', and 'New Client'.
-* 
+*
 * @object buttonProps
 * @property text {string} - Text to show on the button.
 * @property onClick {function} - Optional function to run on button click.
@@ -117,16 +117,15 @@ const FormPartsContainer = function({ title, clarifier, children, navData }) {
           textAlign='center'>
           { title }
         </Header>
-        { !clarifier
-          ? null
-          : (
-            <Header
-              as='h3'
-              textAlign='center'>
-              { clarifier }
-            </Header>
-          )
-        }
+        { !clarifier ? (
+          null
+        ) : (
+          <Header
+            as='h3'
+            textAlign='center'>
+            { clarifier }
+          </Header>
+        ) }
 
         { children }
 

--- a/src/forms/Household.js
+++ b/src/forms/Household.js
@@ -152,7 +152,7 @@ const Role = function ({ member, setMember, snippets }) {
 
     var options = [
       { text: snippets.spouse, value: 'spouse' },
-      { text: snippets.childOther, value: 'member' }, 
+      { text: snippets.childOther, value: 'member' },
     ];
 
     ThisRole = <Dropdown
@@ -220,21 +220,23 @@ const MemberField = function ({ household, time, setHousehold, updateClientValue
       key={ indx }>
 
       <Columns.One>
-        { indx > 0
-          ? <MemberButton
+        { indx > 0 ? (
+          <MemberButton
             className={ 'remove' }
             onClick={ removeMember }
             iconName={ 'remove' } />
-          :
-          <span>{ household.length > 1
-            ? <Icon
-              fitted
-              name={ 'ban' }
-              style={{ color: '#cfcfd0', fontSize: '2.2em', verticalAlign: 'text-top' }} />
-            : null
-          }
+        ) : (
+          <span>
+            { household.length > 1 ? (
+              <Icon
+                fitted
+                name={ 'ban' }
+                style={{ color: '#cfcfd0', fontSize: '2.2em', verticalAlign: 'text-top' }} />
+            ) : (
+              null
+            ) }
           </span>
-        }
+        ) }
       </Columns.One>
 
       <Columns.Two>
@@ -328,9 +330,12 @@ const HouseholdContent = function ({ current, time, updateClientValue, snippets 
 
   var addMember = function (evnt, inputProps) {
 
-    var member = household.length === 1
-      ? { m_age: 30, m_role: 'spouse', m_disabled: false }
-      : { m_age: 12, m_role: 'member', m_disabled: false };
+    var member;
+    if (household.length === 1) {
+      member = { m_age: 30, m_role: 'spouse', m_disabled: false };
+    } else {
+      member = { m_age: 12, m_role: 'member', m_disabled: false };
+    }
 
     household.push(member);
     setHousehold(evnt, household);
@@ -365,7 +370,7 @@ const HouseholdContent = function ({ current, time, updateClientValue, snippets 
         <Columns.Two noMargin={ true }>
           <Header
             as='h4'
-            color={ 'teal' }> 
+            color={ 'teal' }>
             { snippets.addMember }
           </Header>
         </Columns.Two>

--- a/src/forms/Predictions.js
+++ b/src/forms/Predictions.js
@@ -39,11 +39,11 @@ const IncomeForm = function ({ future, time, updateClientValue }) {
       <IntervalColumnHeadings type={ type } />
       <CashFlowInputsRow
         timeState={ future }
-				  type={ type }
-				  time={ time }
-				  updateClientValue = { updateClientValue }
-				  generic='earned'
-				  labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
+        type={ type }
+        time={ time }
+        updateClientValue = { updateClientValue }
+        generic='earned'
+        labelInfo='(Weekly income = hourly wage times average number of work hours per week)'>
           How much money would you get paid in the future? (You can try different amounts)
       </CashFlowInputsRow>
     </div>

--- a/src/forms/ShowOnYes.js
+++ b/src/forms/ShowOnYes.js
@@ -62,7 +62,7 @@ class ShowOnYes extends React.Component {
     return (
       <div className = { `show-on-yes` }>
 
-      	<ContentH1>{ heading }</ContentH1>
+        <ContentH1>{ heading }</ContentH1>
         <ControlledRadioYesNo
           labelText         = { question }
           checked           = { showChildren }

--- a/src/forms/output/BenefitsTable.js
+++ b/src/forms/output/BenefitsTable.js
@@ -30,11 +30,22 @@ const BenefitsTable = function (props) {
   var client = cloneDeep(props.client),
       curr   = client.current;
 
-  var SNAPBenefitCurrent  = curr.hasSnap ? Math.round(getSNAPBenefits(client, 'current')) : 0,
-      SNAPBenefitFuture   = curr.hasSnap ? Math.round(getSNAPBenefits(client, 'future')) : 0,
-      SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
-      sec8BenefitCurrent  = curr.hasSection8 ? Math.round(getSection8Benefit(client, 'current')) : 0,
-      sec8BenefitFuture   = curr.hasSection8 ? Math.round(getSection8Benefit(client, 'future')) : 0,
+  var SNAPBenefitCurrent =  0,
+      SNAPBenefitFuture  =  0,
+      sec8BenefitCurrent = 0,
+      sec8BenefitFuture  = 0;
+
+  if (curr.hasSnap) {
+    SNAPBenefitCurrent = Math.round(getSNAPBenefits(client, 'current'));
+    SNAPBenefitFuture  = Math.round(getSNAPBenefits(client, 'future'));
+  }
+
+  if (curr.hasSection8) {
+    sec8BenefitCurrent = Math.round(getSection8Benefit(client, 'current'));
+    sec8BenefitFuture  = Math.round(getSection8Benefit(client, 'future'));
+  }
+
+  var SNAPDiff            = SNAPBenefitFuture - SNAPBenefitCurrent,
       sec8Diff            = sec8BenefitFuture - sec8BenefitCurrent,
       totalBenefitCurrent = SNAPBenefitCurrent + sec8BenefitCurrent,
       totalBenefitFuture  = SNAPBenefitFuture + sec8BenefitFuture,

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -20,9 +20,9 @@ export default {
   __contactEmail__:           <a href="mailto:andrew@codeforboston.org">andrew@codeforboston.org</a>,
   __namesExceptLast__:        <span>{ contributors.slice(0, -1).join(', ') }</span>,
   __lastName__:               <span>{ contributors[ contributors.length - 1 ] }</span>,
+
   // Footer
-  __heartIcon__:
-    <Icon
-      name='heart'
-      size='small' />,
+  __heartIcon__: <Icon
+    name='heart'
+    size='small' />,
 };

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -22,7 +22,9 @@ export default {
   __lastName__:               <span>{ contributors[ contributors.length - 1 ] }</span>,
 
   // Footer
-  __heartIcon__: <Icon
-    name='heart'
-    size='small' />,
+  __heartIcon__: (
+    <Icon
+      name='heart'
+      size='small' />
+  ),
 };

--- a/src/test/programs/federal/snap/generateTestCases.js
+++ b/src/test/programs/federal/snap/generateTestCases.js
@@ -33,9 +33,12 @@ const elderlyOrDisabled = (changes) => {
     return changes;
   }
 
-  const member = rnd < 2
-    ? Object.assign({}, defaultMember, { m_disabled: true })
-    : Object.assign({}, defaultMember, { m_age: 61 });
+  let member;
+  if (rnd < 2) {
+    member = Object.assign({}, defaultMember, { m_disabled: true });
+  } else {
+    member = Object.assign({}, defaultMember, { m_age: 61 });
+  }
   changes.household.push(member);
   return changes;
 };
@@ -80,7 +83,7 @@ const possibleHousings = [
   'homeless',
   'houseowner',
   'renter',
-  'voucher', 
+  'voucher',
 ];
 const housings = (changes) => {
   changes.housing = sample(possibleHousings);
@@ -92,7 +95,7 @@ const possibleUtilityBrackets = [
   'Heating',
   'Non-heating',
   'Telephone',
-  'None', 
+  'None',
 ];
 const utilityBrackets = (changes) => {
   switch (sample(possibleUtilityBrackets)) {
@@ -122,7 +125,7 @@ const housingFeeNames =
     'propertyTax',
     'housingInsurance',
     'rent',
-    'rentShare', 
+    'rentShare',
   ];
 const housingFees = (changes) => {
   housingFeeNames.forEach((name) => {


### PR DESCRIPTION
I noticed that in some places, there were tabs instead of spaces and the linter wasn't warning about it, so I looked into it. I added the `react/jsx-indent` and `react/jsx-indent-props` eslint rules to catch these instances (and more generally enforce indentation within components).

 This also caused some issues with the ternary operators in CurrentExpenses.js, so to resolve this I put parentheses around the components within the operators where necessary. I think this is more consistent (keeping with the convention of starting whatever comes after the `?` or `:` on the same line), but we could discuss whether this is the style we want.