### PR TITLE
Add maximum value to income/expense text fields

### DIFF
--- a/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
+++ b/src/test/forms/__snapshots__/CashFlowRow.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CashFlowInputsRow should match snapshot 1`] = `
 <CashFlowContainer
   label="label"
-  message={null}
+  message=""
   validRow={true}
 >
   <ManagedNumberField


### PR DESCRIPTION
Adds a $999999.99/yr ($19230.76/wk, $83333.33/mo) maximum value to the fields for income and expenses. Exceeding the maximum value will not update the number and shows a warning, just like how the monthly rent verification works.

To implement this I had to change the CashFlowInputsRow object from a method to a class, and I am not 100% sure that I did the conversion correctly, so please look over what I did in the commits.