### PR TITLE
Fixes #725 Link Cliff Effects Tool to github repo

### DIFF
--- a/src/localization/de.js
+++ b/src/localization/de.js
@@ -6,7 +6,12 @@ export default {
   header: {},
 
   footer: {
-    header:    `Cliff Effects Tool`,
+    header: [
+      {
+        name: `__githubRepoLink__`,
+        text: `Cliff Effects Werkzeug`,
+      },
+    ],
     cfbCredit: [
       `Mit `,
       { name: `__heartIcon__` },

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -6,7 +6,12 @@ export default {
   header: {},
 
   footer: {
-    header:    `Cliff Effects Tool`,
+    header: [
+      {
+        name: `__githubRepoLink__`,
+        text: `Cliff Effects Tool`,
+      },
+    ],
     cfbCredit: [
       `Made with `,
       { name: `__heartIcon__` },

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -6,7 +6,12 @@ export default {
   header: {},
 
   footer: {
-    header:         `Cliff Effects Tool`,
+    header: [
+      {
+        name: `__githubRepoLink__`,
+        text: `Cliff Effects Herriamienta`,
+      },
+    ],
     cfbCreditIntro: `Made with `,
     cfbCredit:      ` by Code for Boston`,
   },

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -27,4 +27,5 @@ export default {
       name='heart'
       size='small' />
   ),
+  __githubRepoLink__:       <ExternalLink href='https://github.com/codeforboston/cliff-effects' />,
 };

--- a/src/localization/zh.js
+++ b/src/localization/zh.js
@@ -7,7 +7,12 @@ export default {
   header: {},
 
   footer: {
-    'header_v1.0':    `懸崖效應工具`,
+    header: [
+      {
+        name: `__githubRepoLink__`,
+        text: `懸崖效應工具`,
+      },
+    ],
     'cfbCredit_v1.0': [
       `由 Code for Boston 用 `,
       { name: `__heartIcon__` },


### PR DESCRIPTION
I took a stab at issue #725.  I added an inline component under the footer section that is an external link component without text.  This allows the settings in the localization files to pass text instead of it being hard-coded.  I went that route since the about page also has a link to the repo, but with text of 'GitHub'.  Perhaps makes sense to standardize and have only one github inline component.  This one could easily be reused by the about page with the appropriate updates to the localization files.