### PR TITLE
Fixes styling for footer link, adds flexibility to `ExternalLink`

### DIFF
--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -4,7 +4,6 @@ import {
   // Generic Form stuff
   Label,
   Icon,
-  Container,
 } from 'semantic-ui-react';
 
 // ========================================
@@ -16,12 +15,12 @@ import {
  */
 const ExternalLink = function ({ href, children, ...otherProps }) {
   return (
-    <Container
-      href={ href }
-      target='_blank'
+    <a
+      href   = { href }
+      target = { `_blank` }
       { ...otherProps }>
       {children}
-    </Container>
+    </a>
   );
 };
 

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -4,6 +4,7 @@ import {
   // Generic Form stuff
   Label,
   Icon,
+  Container,
 } from 'semantic-ui-react';
 
 // ========================================
@@ -13,12 +14,15 @@ import {
 /**
  * Link that opens new tab
  */
-const ExternalLink = function ({ href, children }) {
+const ExternalLink = function ({ href, children, ...otherProps }) {
   return (
-    <a
+    <Container
       href={ href }
-      target='_blank'>{children}
-    </a>);
+      target='_blank'
+      { ...otherProps }>
+      {children}
+    </Container>
+  );
 };
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,13 @@ form .field-aligner {
   flex-direction: column;
 }
 
+
+/* Fixing (currently) link styles */
+.neutral-link {
+  color: white;
+}
+
+
 /*
 Used to fill vertical space.
 `height: 100%` doesn't work with Flexbox on Mobile Safari.

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -27,5 +27,7 @@ export default {
       name='heart'
       size='small' />
   ),
-  __githubRepoLink__:       <ExternalLink href='https://github.com/codeforboston/cliff-effects' />,
+  __githubRepoLink__: <ExternalLink
+    href='https://github.com/codeforboston/cliff-effects'
+    as={ 'content' } />,
 };

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -28,6 +28,6 @@ export default {
       size='small' />
   ),
   __githubRepoLink__: <ExternalLink
-    href='https://github.com/codeforboston/cliff-effects'
-    as={ 'content' } />,
+    className = { `neutral-link` }
+    href      = { `https://github.com/codeforboston/cliff-effects` } />,
 };

--- a/src/utils/interpolation.js
+++ b/src/utils/interpolation.js
@@ -27,12 +27,16 @@ const interpolateText = function (template, components, langCode) {
       return null;
     }
 
+    // Item is component
+    var component = components[ item.name ];
+    props.className = props.className + ` ` + component.props.className;
+
     if (item.text) {
       // replace inner text
-      return React.cloneElement(components[ item.name ], props, item.text);
+      return React.cloneElement(component, props, item.text);
     } else {
       // otherwise just add the required key and the language code
-      return React.cloneElement(components[ item.name ], props);
+      return React.cloneElement(component, props);
     }
   });
 };


### PR DESCRIPTION
This is making me doubt our way of doing snippets. Someone I was chatting with suggested something I think has been suggested before. I think I was one of the people against it then because I wanted to simplify how snippets would be used in the code, but it may be worth revisiting:
```
<span className={ 'neutral-link' }><T snippet={ snippets.name }></span>
```

Another option is to use functions instead of components in 'inlineComponents.js.'

I dunno. It hasn't caused a lot of trouble, so maybe it's not worth it right now. I'm open to opinions.