### PR TITLE
Fix StackedAreaGraph not adjusting to future income and not redrawing

### DIFF
--- a/src/forms/output/StackedAreaGraph.js
+++ b/src/forms/output/StackedAreaGraph.js
@@ -47,22 +47,22 @@ class StackedAreaGraph extends Component {
     const { client, timescale, activePrograms } = this.props;
     const multiplier = multipliers[ timescale ];
 
-    // Adjust to time-interval, round to hundreds
-    // var max       = Math.ceil((MAX_X_MONTHLY * multiplier) / 100) * 100,
-    var max       = Math.ceil((limits.max * multiplier) / 100) * 100,
-        interval  = Math.ceil((max / 100) / 10) * 10;
-
     var withIncome    = activePrograms.slice();
     withIncome.unshift('income');
 
-    var xRange        = _.range(limits.min, max, interval),
+    // Adjust to time-interval, round to hundreds
+    var income        = client.future.earned * multiplier,
+        max           = Math.max(income, limits.max * multiplier),
+        xMax          = Math.ceil(max / 100) * 100,
+        xMin          = Math.ceil(limits.min * multiplier / 100) * 100,
+        interval      = Math.ceil(((xMax - xMin) / 100) / 10) * 10,
+        xRange        = _.range(xMin, xMax + interval, interval),
         extraProps    = { income: { fill: 'origin' }},
         datasets      = getDatasets(xRange, client, multiplier, withIncome, extraProps);
 
     // react-chartjs-2 keeps references to plugins, so we
     // have to mutate that reference
-    var income  = client.future.earned * multiplier,
-        hack    = this.state.verticalLine;
+    var hack    = this.state.verticalLine;
     hack.xRange = xRange;
     hack.income = income;
 
@@ -117,6 +117,7 @@ class StackedAreaGraph extends Component {
         },  // end `tooltips`
       },  // end `options`
       plugins: [ this.state.verticalLine ],
+      redraw:  true,
     };  // end `stackedAreaProps`
 
     return (


### PR DESCRIPTION
This fixes a crash in `VerticalLine.js` caused by not taking the future income into account when calculating the x-axis range for the `StackedAreaGraph`. Basically I just changed it so that the axis maximum is equal to or greater than both the max specified in `PROGRAM_CHART_VALUES` and the input income. 

I also cleaned up the math a little, adjusting the minimum according to the timescale the same way as the maximum (which doesn't matter now since it's 0, but just in case), and I added `redraw: true` to the `stackedAreaProps`. The latter is because I noticed that the graph wouldn't update if just the income and not the xRange changed. I believe this is because only the plugin cares about `income` (not the chart itself), so it doesn't know to update if only `income` changes. Not totally confident about this, since the graph seems to update many times for any change, but at least for me the performance is still good.

Finally, if you enter a ridiculously high value, you will eventually get a crash, so we also need to pull in #731 for this to be totally bug-free.