### PR TITLE
Focus styles on the feedback form work, styles tweaked - #816

### DIFF
--- a/src/components/prompts/FeedbackForm.js
+++ b/src/components/prompts/FeedbackForm.js
@@ -176,6 +176,8 @@ class FeedbackPrompt extends React.Component {
       };
     };
 
+    // Without the #root selector, we can't get the accessibility
+    // focus styles to win 
     return (
       <Modal
         mountNode = { document.getElementById(`root`) }
@@ -227,6 +229,7 @@ class FeedbackPrompt extends React.Component {
         </Modal.Actions>
 
         <Modal
+          mountNode = { document.getElementById(`root`) }
           size               = { `large` }
           open               = { this.state.ready }
           onClose            = { this.closeAskPermission }

--- a/src/components/prompts/FeedbackForm.js
+++ b/src/components/prompts/FeedbackForm.js
@@ -180,7 +180,7 @@ class FeedbackPrompt extends React.Component {
     // focus styles to win 
     return (
       <Modal
-        mountNode = { document.getElementById(`root`) }
+        mountNode = { document.getElementById(`App`) }
         size='large'
         open={ this.props.isOpen }
         onClose={ this.close }
@@ -229,7 +229,7 @@ class FeedbackPrompt extends React.Component {
         </Modal.Actions>
 
         <Modal
-          mountNode = { document.getElementById(`root`) }
+          mountNode = { document.getElementById(`App`) }
           size               = { `large` }
           open               = { this.state.ready }
           onClose            = { this.closeAskPermission }

--- a/src/components/prompts/FeedbackForm.js
+++ b/src/components/prompts/FeedbackForm.js
@@ -178,6 +178,7 @@ class FeedbackPrompt extends React.Component {
 
     return (
       <Modal
+        mountNode = { document.getElementById(`root`) }
         size='large'
         open={ this.props.isOpen }
         onClose={ this.close }
@@ -188,6 +189,7 @@ class FeedbackPrompt extends React.Component {
         <Modal.Content scrolling>
           <Form>
             <Form.Input
+              autoFocus
               { ...inputProps('currentSnap') }
               label={ 'If amount for the CURRENT SNAP subsidy was wrong, what\'s the correct amount?' } />
             <Form.Input

--- a/src/index.css
+++ b/src/index.css
@@ -467,12 +467,13 @@ i.icon.details-icon {
 ACCESSIBILITY
 =================
 */
-#root *:focus {
+body .ui *:focus {
   outline: 5px double rgba(0, 121, 116, 1);
   outline-offset: 2px;
   z-index: 1;
 }
 
+/* Without #root, these selectors don't win */
 #root input:focus~label:before,
 #root .form *:focus {
   border: 1px solid rgba(0, 121, 116, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -467,13 +467,14 @@ i.icon.details-icon {
 ACCESSIBILITY
 =================
 */
-#App *:focus {
+#root *:focus {
   outline: 5px double rgba(0, 121, 116, 1);
   outline-offset: 2px;
+  z-index: 1;
 }
 
-#App .ui input:focus~label:before,
-#App .ui input:focus {
+#root input:focus~label:before,
+#root .form *:focus {
   border: 1px solid rgba(0, 121, 116, 1);
   outline: 2px solid rgba(0, 121, 116, 1);
   outline-offset: 1px;


### PR DESCRIPTION
tweaked to put a single border around form elements and double borders
around non-form elements. Should the bottom buttons should be
taken out of the form?

Another question is do 'Cancel' and 'Submit' buttons on modals count as form elements?

The difference in style is because things like check boxes and radio buttons get overwhelmed if they have the double border. Should we just not have a double border on anything? Should we have a double border around everything except check boxes and radio buttons?

What this doesn't do is fix the fact that stuff behind the modal still gets focus while the modal is open. It's a bit of a puzzler. First off, I haven't found a way to do it with CSS - I just can't access previous siblings or anything like that. That means that we'd have to manage it from the previous sibling side of things, which would be kind of messy. Possibilities are a class and `user-select: none;` CSS rule, an attribute of 'unselectible' or whatever (for Safari?), or disabling the inputs somehow (does disabling a parent disable everything in it?).

Anywho, them's the breaks. Not sure what we want to do about that.
