### PR TITLE
Predictions warning modal (formerly Terms and Conditions modal)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,6 @@ class App extends Component {
      *  @property {boolean} devProps.dev - whether dev HUD is turned on
      *  @property {boolean} devProps.english - whether to highlight English snippets
      *  @property {boolean} devProps.nonEnglish - whether to highlight snippets in the current language, if that language is not English
-     *  @property {boolean} termsAccepted=false - displays a modal until user accepts terms and conditions of the site (currently indicates this is a prototype)
      */
     this.state = {
       langCode: `en`,

--- a/src/App.js
+++ b/src/App.js
@@ -69,6 +69,7 @@ class App extends Component {
      *  @property {boolean} devProps.dev - whether dev HUD is turned on
      *  @property {boolean} devProps.english - whether to highlight English snippets
      *  @property {boolean} devProps.nonEnglish - whether to highlight snippets in the current language, if that language is not English
+     *  @property {boolean} termsAccepted - displays modal to accept terms before allowing user to fill out form
      */
     this.state = {
       langCode: `en`,
@@ -86,6 +87,7 @@ class App extends Component {
         nonEnglish: true,
         ...localDev,
       },
+      termsAccepted: false,
     };
   };  // End constructor()
 
@@ -160,12 +162,23 @@ class App extends Component {
     return classes;
   };  // End propsToClasses()
 
+  /** Toggles termsAccepted flag in app state.  Passed to TermsAndConditions modal
+   * which calls this in the onClose handler.  App is unavailable until terms 
+   * are accepted.
+   * @method
+   * @param {boolean} termsAccepted
+   */
+  toggleAcceptTerms = (termsAccepted) => {
+    this.setState({ termsAccepted });
+  };  // End acceptTerms()
+
   render () {
     var {
       langCode,
       snippets,
       devProps,
       clients,
+      termsAccepted,
     } = this.state;
 
     var confirmer = new Confirmer(),  // Makes sure user doesn't accidentally lose work
@@ -174,6 +187,9 @@ class App extends Component {
           setDev:      this.setDev,
           loadClient:  this.loadClient,
           setLanguage: this.setLanguage,
+        },
+        funcs     = {
+          toggleAcceptTerms: this.toggleAcceptTerms,
         },
         clientData = clients.loaded;
 
@@ -220,9 +236,11 @@ class App extends Component {
                   return (
                     <VisitPage
                       { ...props }
-                      confirmer  = { confirmer }
-                      snippets   = {{ ...snippets.visitPage, langCode: snippets.langCode }}
-                      clientData = { clientData } />);
+                      termsAccepted = { termsAccepted }
+                      funcs         = { funcs }
+                      confirmer     = { confirmer }
+                      snippets      = {{ ...snippets.visitPage, langCode: snippets.langCode }}
+                      clientData    = { clientData } />);
                 } } />
 
               {/* For managing our development HUD */}

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,8 @@ import { CLIENT_DEFAULTS } from './utils/CLIENT_DEFAULTS';
 // LOCALIZATION
 import { getTextForLanguage } from './utils/getTextForLanguage';
 
+import TermsAndConditions from './components/prompts/TermsAndConditions';
+
 /**
  * Main top-level component of the app. Contains the router that controls access
  * to the {@link HomePage}, {@link VisitPage}, and {@link AboutPage}, as well
@@ -69,6 +71,7 @@ class App extends Component {
      *  @property {boolean} devProps.dev - whether dev HUD is turned on
      *  @property {boolean} devProps.english - whether to highlight English snippets
      *  @property {boolean} devProps.nonEnglish - whether to highlight snippets in the current language, if that language is not English
+     *  @property {boolean} termsAccepted=false - displays a modal until user accepts terms and conditions of the site (currently indicates this is a prototype)
      */
     this.state = {
       langCode: `en`,
@@ -86,6 +89,7 @@ class App extends Component {
         nonEnglish: true,
         ...localDev,
       },
+      termsAccepted: false,
     };
   };  // End constructor()
 
@@ -122,6 +126,16 @@ class App extends Component {
       }
     });
   };  // End setDev()
+
+  /** Toggles termsAccepted flag in app state.  Passed to TermsAndConditions modal
+   * which calls this in the onClose handler.  App is unavailable until terms 
+   * are accepted.
+   * @method
+   * @param {boolean} termsAccepted
+   */
+  toggleAcceptTerms = (termsAccepted) => {
+    this.setState({ termsAccepted });
+  };  // End acceptTerms()
 
   /** Load an individual client's data. Currently, the only source of client
    * data to load is a text input field in the Dev HUD.
@@ -166,6 +180,7 @@ class App extends Component {
       snippets,
       devProps,
       clients,
+      termsAccepted,
     } = this.state;
 
     var confirmer = new Confirmer(),  // Makes sure user doesn't accidentally lose work
@@ -246,6 +261,13 @@ class App extends Component {
             funcs    = { devFuncs }
             data     = {{ default: clients.default }}
             state    = { this.state } />
+        ))}
+
+        { renderIfTrue(termsAccepted === false, (
+          <TermsAndConditions
+            termsAccepted = { termsAccepted }
+            toggleAcceptTerms = { this.toggleAcceptTerms }
+            snippets={{ ...snippets.policies }} />
         ))}
 
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -28,8 +28,6 @@ import { CLIENT_DEFAULTS } from './utils/CLIENT_DEFAULTS';
 // LOCALIZATION
 import { getTextForLanguage } from './utils/getTextForLanguage';
 
-import TermsAndConditions from './components/prompts/TermsAndConditions';
-
 /**
  * Main top-level component of the app. Contains the router that controls access
  * to the {@link HomePage}, {@link VisitPage}, and {@link AboutPage}, as well
@@ -89,7 +87,6 @@ class App extends Component {
         nonEnglish: true,
         ...localDev,
       },
-      termsAccepted: false,
     };
   };  // End constructor()
 
@@ -126,16 +123,6 @@ class App extends Component {
       }
     });
   };  // End setDev()
-
-  /** Toggles termsAccepted flag in app state.  Passed to TermsAndConditions modal
-   * which calls this in the onClose handler.  App is unavailable until terms 
-   * are accepted.
-   * @method
-   * @param {boolean} termsAccepted
-   */
-  toggleAcceptTerms = (termsAccepted) => {
-    this.setState({ termsAccepted });
-  };  // End acceptTerms()
 
   /** Load an individual client's data. Currently, the only source of client
    * data to load is a text input field in the Dev HUD.
@@ -180,7 +167,6 @@ class App extends Component {
       snippets,
       devProps,
       clients,
-      termsAccepted,
     } = this.state;
 
     var confirmer = new Confirmer(),  // Makes sure user doesn't accidentally lose work
@@ -262,14 +248,6 @@ class App extends Component {
             data     = {{ default: clients.default }}
             state    = { this.state } />
         ))}
-
-        { renderIfTrue(termsAccepted === false, (
-          <TermsAndConditions
-            termsAccepted = { termsAccepted }
-            toggleAcceptTerms = { this.toggleAcceptTerms }
-            snippets={{ ...snippets.policies }} />
-        ))}
-
       </div>
     );
   };  // End render()

--- a/src/components/prompts/PredictionsWarning.js
+++ b/src/components/prompts/PredictionsWarning.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import {
   Button,
+  Checkbox,
   Form,
   Modal,
-  Radio,
 } from 'semantic-ui-react';
 
 /**
@@ -16,7 +16,22 @@ import {
  */
 class TermsAndConditions extends Component {
   
-  state = { canCountOnPredictions: null };
+  state = { 
+    checkbox1: false,
+    checkbox2: false,
+  };
+
+  handleChange = (checkboxField) => {
+    let checked = !this.state[ checkboxField ];
+    this.setState({ [ checkboxField ]: checked });
+  };
+
+  allowContinue = () => {
+    return (
+      this.state.checkbox1 === true && 
+      this.state.checkbox2 === true
+    ) ? true : false;
+  };
 
   closeModal = (accept) => {
     if (accept) {
@@ -24,10 +39,6 @@ class TermsAndConditions extends Component {
     } else {
       this.props.history.push('/');
     }
-  };
-
-  handleChange = (canCountOnPredictions) => {
-    this.setState({ canCountOnPredictions });
   };
 
   render() {
@@ -54,27 +65,31 @@ class TermsAndConditions extends Component {
 
           <h4>{ snippets.i_formInstructions }</h4>
 
-          <div className="radio-yes-no">
+          <div
+            className="radio-yes-no"
+            key= { `ReqCkBx1` }>
             <Form.Field>
-              <Radio
-                checked={ this.state.canCountOnPredictions === true }
-                name="CanCountOn"
-                onClick={ () => this.handleChange(true) } />
+              <Checkbox
+                checked = { this.state.Checkbox1 }
+                name    = { `checkbox1` }
+                onClick = { () => this.handleChange('checkbox1') } />
             </Form.Field>
             <Form.Field>
-              { snippets.i_radioYesLabel }
+              { snippets.i_checkboxLabel1 }
             </Form.Field>
           </div>
-         
-          <div className="radio-yes-no">
+
+          <div
+            className="radio-yes-no"
+            key= { `ReqCkBx2` }>
             <Form.Field>
-              <Radio
-                checked={ this.state.canCountOnPredictions === false }
-                name="CanCountOn"
-                onClick={ () => this.handleChange(false) } />
+              <Checkbox
+                checked = { this.state.Checkbox2 }
+                name    = { `checkbox2` }
+                onClick = { () => this.handleChange('checkbox2') } />
             </Form.Field>
             <Form.Field>
-              { snippets.i_radioNoLabel }
+              { snippets.i_checkboxLabel2 }
             </Form.Field>
           </div>
          
@@ -85,7 +100,7 @@ class TermsAndConditions extends Component {
             { snippets.i_buttonCancel }
           </Button>
           <Button
-            disabled={ this.state.canCountOnPredictions === false ? false : true }
+            disabled={ !this.allowContinue() }
             onClick={ () => this.closeModal(true) }
             color='teal'>
             { snippets.i_buttonAcceptWarning }

--- a/src/components/prompts/PredictionsWarning.js
+++ b/src/components/prompts/PredictionsWarning.js
@@ -50,9 +50,9 @@ class TermsAndConditions extends Component {
         </Modal.Header>
         <Modal.Content scrolling>
 
-          { snippets.i_terms } 
+          { snippets.i_warning } 
 
-          <h4>{ snippets.i_formHeader }</h4>
+          <h4>{ snippets.i_formInstructions }</h4>
 
           <div className="radio-yes-no">
             <Form.Field>
@@ -62,7 +62,7 @@ class TermsAndConditions extends Component {
                 onClick={ () => this.handleChange(true) } />
             </Form.Field>
             <Form.Field>
-              { snippets.i_fieldYesLabel }
+              { snippets.i_radioYesLabel }
             </Form.Field>
           </div>
          
@@ -74,7 +74,7 @@ class TermsAndConditions extends Component {
                 onClick={ () => this.handleChange(false) } />
             </Form.Field>
             <Form.Field>
-              { snippets.i_fieldNoLabel }
+              { snippets.i_radioNoLabel }
             </Form.Field>
           </div>
          
@@ -82,13 +82,13 @@ class TermsAndConditions extends Component {
         <Modal.Actions>
           <Button
             onClick={ () => this.closeModal(false) }>
-            { snippets.i_buttonCancelAccept }
+            { snippets.i_buttonCancel }
           </Button>
           <Button
             disabled={ this.state.canCountOnPredictions === false ? false : true }
             onClick={ () => this.closeModal(true) }
             color='teal'>
-            { snippets.i_buttonAcceptTerms }
+            { snippets.i_buttonAcceptWarning }
           </Button>
         </Modal.Actions>
       </Modal>

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import {
   Button,
+  Form,
   Modal,
+  Radio,
 } from 'semantic-ui-react';
 
 /**
@@ -13,27 +15,18 @@ import {
  */
 class TermsAndConditions extends Component {
   
-  state = { showPrivacy: false };
+  state = { canCountOnPredictions: null };
 
   closeModal = () => {
     this.props.toggleAcceptTerms();
   };
 
-  renderTermsSection = ({ i_header, i_terms }) => {
-    return (
-      <div>
-        <h4>{ i_header }</h4>
-        {
-          i_terms.map((term) => {
-            return <p key={ `p_${term.key}` }>{ term }</p>;
-          })
-        }
-      </div>
-    );
-  }
+  handleChange = (canCountOnPredictions) => {
+    this.setState({ canCountOnPredictions });
+  };
 
   render() {
-
+  
     const {
       termsAccepted,
       snippets,
@@ -48,21 +41,37 @@ class TermsAndConditions extends Component {
         closeOnDimmerClick={ false }
         closeOnEscape={ false }>
         <Modal.Header> 
-          Terms and Conditions
+          { snippets.i_header }
         </Modal.Header>
         <Modal.Content scrolling>
-          { this.renderTermsSection(snippets.termsOfUse) } 
+
+          { snippets.i_terms } 
+
+          <h5>{ snippets.i_formHeader }</h5>
+
+          <Form>
+            <Form.Field>
+              <Radio
+                label={ snippets.i_fieldYesLabel.props.children }
+                checked={ this.state.canCountOnPredictions === true }
+                onClick={ () => this.handleChange(true) } />
+            </Form.Field>
+            <Form.Field>
+              <Radio
+                label={ snippets.i_fieldNoLabel.props.children }
+                checked={ this.state.canCountOnPredictions === false }
+                onClick={ () => this.handleChange(false) } />
+            </Form.Field>
+          </Form>
+         
         </Modal.Content>
         <Modal.Actions>
-          {
-            !this.state.showPrivacy ?
-              <Button
-                onClick={ this.closeModal }
-                color='red'>
-                { snippets.i_buttonAcceptTerms }
-              </Button> :
-              null
-          }
+          <Button
+            disabled={ this.state.canCountOnPredictions === false ? false : true }
+            onClick={ this.closeModal }
+            color='red'>
+            { snippets.i_buttonAcceptTerms }
+          </Button>
         </Modal.Actions>
       </Modal>
     ); // End return()

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -58,6 +58,7 @@ class TermsAndConditions extends Component {
             <Form.Field>
               <Radio
                 checked={ this.state.canCountOnPredictions === true }
+                name="CanCountOn"
                 onClick={ () => this.handleChange(true) } />
             </Form.Field>
             <Form.Field>
@@ -69,6 +70,7 @@ class TermsAndConditions extends Component {
             <Form.Field>
               <Radio
                 checked={ this.state.canCountOnPredictions === false }
+                name="CanCountOn"
                 onClick={ () => this.handleChange(false) } />
             </Form.Field>
             <Form.Field>

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -19,11 +19,6 @@ class TermsAndConditions extends Component {
     this.props.toggleAcceptTerms();
   };
 
-  togglePrivacy = () => {
-    let showPrivacy = !this.state.showPrivacy;
-    this.setState({ showPrivacy });
-  };
-
   renderTermsSection = ({ i_header, i_terms }) => {
     return (
       <div>
@@ -56,11 +51,7 @@ class TermsAndConditions extends Component {
           Terms and Conditions
         </Modal.Header>
         <Modal.Content scrolling>
-          {
-            !this.state.showPrivacy ?
-              this.renderTermsSection(snippets.termsOfUse) :
-              this.renderTermsSection(snippets.privacyAndCookies)
-          } 
+          { this.renderTermsSection(snippets.termsOfUse) } 
         </Modal.Content>
         <Modal.Actions>
           {
@@ -72,10 +63,6 @@ class TermsAndConditions extends Component {
               </Button> :
               null
           }
-          <Button
-            onClick={ this.togglePrivacy }>
-            { this.state.showPrivacy ? snippets.i_buttonBackToTerms : snippets.i_buttonViewPrivacy }
-          </Button>
         </Modal.Actions>
       </Modal>
     ); // End return()

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -1,50 +1,86 @@
-import React from 'react';
+import React, { Component } from 'react';
 import {
   Button,
   Modal,
 } from 'semantic-ui-react';
-
 // import * as classes from './TermsAndConditions.css';
 
 /**
- * Modal that shows the feedback form.
+ * Displays a model that requires the user to accept the terms and conditions before using the app
+ * @extends React.Component
+ * @param {boolean} termsAccepted - boolean indicating whether terms and conditions have been accepted by the user
+ * @param {function} toggleAcceptTerms - function to set the termsAccepted in app state
+ * @param {object} snippets - object containing localization snippets
  */
-const TermsAndConditions = (props) => {
+class TermsAndConditions extends Component {
+  
+  state = { showPrivacy: false };
 
-  const closeModal = () => {
-    console.log('closeModal()');
-    props.toggleAcceptTerms();
+  closeModal = () => {
+    this.props.toggleAcceptTerms();
   };
 
-  const {
-    termsAccepted,
-    snippets,
-  } = props;
+  togglePrivacy = () => {
+    let showPrivacy = !this.state.showPrivacy;
+    this.setState({ showPrivacy });
+  };
 
-  return (
-    <Modal
-      size='large'
-      open={ !termsAccepted }
-      onClose={ closeModal }
-      closeOnDimmerClick={ false }
-      closeOnEscape={ false } >
-      <Modal.Header> 
-        {/* className={ classes.modalHeader } */}
-        Terms and Conditions
-      </Modal.Header>
-      <Modal.Content scrolling>
-        { snippets.i_termsOfUse } 
-      </Modal.Content>
-      <Modal.Actions>
-        <Button
-          onClick={ closeModal }
-          color='red'>
-          Accept
-        </Button>
-      </Modal.Actions>
-    </Modal>
-  );
+  renderTerms = ({ i_header, i_terms }) => {
+    return (
+      <div>
+        <h4>{ i_header }</h4>
+        {
+          i_terms.map((term) => {
+            return <p key={ `p_${term.key}` }>{ term }</p>;
+          })
+        }
+      </div>
+    );
+  }
+
+  render() {
+
+    const {
+      termsAccepted,
+      snippets,
+    } = this.props;
+
+    return (
+      <Modal
+        size='large'
+        open={ !termsAccepted }
+        onClose={ this.closeModal }
+        closeOnDimmerClick={ false }
+        closeOnEscape={ false } >
+        <Modal.Header> 
+          {/* className={ classes.modalHeader } */}
+          Terms and Conditions
+        </Modal.Header>
+        <Modal.Content scrolling>
+          {
+            !this.state.showPrivacy ?
+              this.renderTerms(snippets.termsOfUse) :
+              this.renderTerms(snippets.privacyAndCookies)
+          } 
+        </Modal.Content>
+        <Modal.Actions>
+          {
+            !this.state.showPrivacy ?
+              <Button
+                onClick={ this.closeModal }
+                color='red'>
+                { snippets.i_buttonAcceptTerms }
+              </Button> :
+              null
+          }
+          <Button
+            onClick={ this.togglePrivacy }>
+            { this.state.showPrivacy ? snippets.i_buttonBackToTerms : snippets.i_buttonViewPrivacy }
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    ); // End return()
+  } // End render()
 };
 
 export default TermsAndConditions;
-// export { AskPermission };

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
 import {
   Button,
   Form,
@@ -17,8 +18,12 @@ class TermsAndConditions extends Component {
   
   state = { canCountOnPredictions: null };
 
-  closeModal = () => {
-    this.props.toggleAcceptTerms();
+  closeModal = (accept) => {
+    if (accept) {
+      this.props.toggleAcceptTerms();
+    } else {
+      this.props.history.push('/');
+    }
   };
 
   handleChange = (canCountOnPredictions) => {
@@ -38,7 +43,6 @@ class TermsAndConditions extends Component {
         mountNode = { document.getElementById('App') }
         size='large'
         open={ !termsAccepted }
-        onClose={ this.closeModal }
         closeOnDimmerClick={ false }
         closeOnEscape={ false }>
         <Modal.Header> 
@@ -48,7 +52,7 @@ class TermsAndConditions extends Component {
 
           { snippets.i_terms } 
 
-          <h5>{ snippets.i_formHeader }</h5>
+          <h4>{ snippets.i_formHeader }</h4>
 
           <div className="radio-yes-no">
             <Form.Field>
@@ -75,8 +79,12 @@ class TermsAndConditions extends Component {
         </Modal.Content>
         <Modal.Actions>
           <Button
+            onClick={ () => this.closeModal(false) }>
+            { snippets.i_buttonCancelAccept }
+          </Button>
+          <Button
             disabled={ this.state.canCountOnPredictions === false ? false : true }
-            onClick={ this.closeModal }
+            onClick={ () => this.closeModal(true) }
             color='red'>
             { snippets.i_buttonAcceptTerms }
           </Button>
@@ -86,4 +94,4 @@ class TermsAndConditions extends Component {
   } // End render()
 };
 
-export default TermsAndConditions;
+export default withRouter(TermsAndConditions);

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -85,7 +85,7 @@ class TermsAndConditions extends Component {
           <Button
             disabled={ this.state.canCountOnPredictions === false ? false : true }
             onClick={ () => this.closeModal(true) }
-            color='red'>
+            color='teal'>
             { snippets.i_buttonAcceptTerms }
           </Button>
         </Modal.Actions>

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -3,7 +3,6 @@ import {
   Button,
   Modal,
 } from 'semantic-ui-react';
-// import * as classes from './TermsAndConditions.css';
 
 /**
  * Displays a model that requires the user to accept the terms and conditions before using the app
@@ -47,11 +46,12 @@ class TermsAndConditions extends Component {
 
     return (
       <Modal
+        id={ `WarningModal` }
         size='large'
         open={ !termsAccepted }
         onClose={ this.closeModal }
         closeOnDimmerClick={ false }
-        closeOnEscape={ false } >
+        closeOnEscape={ false }>
         <Modal.Header> 
           {/* className={ classes.modalHeader } */}
           Terms and Conditions

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  Button,
+  Modal,
+} from 'semantic-ui-react';
+
+// import * as classes from './TermsAndConditions.css';
+
+/**
+ * Modal that shows the feedback form.
+ */
+const TermsAndConditions = (props) => {
+
+  const closeModal = () => {
+    console.log('closeModal()');
+    props.toggleAcceptTerms();
+  };
+
+  const {
+    termsAccepted,
+    snippets,
+  } = props;
+
+  return (
+    <Modal
+      size='large'
+      open={ !termsAccepted }
+      onClose={ closeModal }
+      closeOnDimmerClick={ false }
+      closeOnEscape={ false } >
+      <Modal.Header> 
+        {/* className={ classes.modalHeader } */}
+        Terms and Conditions
+      </Modal.Header>
+      <Modal.Content scrolling>
+        { snippets.i_termsOfUse } 
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          onClick={ closeModal }
+          color='red'>
+          Accept
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default TermsAndConditions;
+// export { AskPermission };

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -35,6 +35,7 @@ class TermsAndConditions extends Component {
     return (
       <Modal
         id={ `WarningModal` }
+        mountNode = { document.getElementById('App') }
         size='large'
         open={ !termsAccepted }
         onClose={ this.closeModal }
@@ -49,20 +50,27 @@ class TermsAndConditions extends Component {
 
           <h5>{ snippets.i_formHeader }</h5>
 
-          <Form>
+          <div className="radio-yes-no">
             <Form.Field>
               <Radio
-                label={ snippets.i_fieldYesLabel.props.children }
                 checked={ this.state.canCountOnPredictions === true }
                 onClick={ () => this.handleChange(true) } />
             </Form.Field>
             <Form.Field>
+              { snippets.i_fieldYesLabel }
+            </Form.Field>
+          </div>
+         
+          <div className="radio-yes-no">
+            <Form.Field>
               <Radio
-                label={ snippets.i_fieldNoLabel.props.children }
                 checked={ this.state.canCountOnPredictions === false }
                 onClick={ () => this.handleChange(false) } />
             </Form.Field>
-          </Form>
+            <Form.Field>
+              { snippets.i_fieldNoLabel }
+            </Form.Field>
+          </div>
          
         </Modal.Content>
         <Modal.Actions>

--- a/src/components/prompts/TermsAndConditions.js
+++ b/src/components/prompts/TermsAndConditions.js
@@ -24,7 +24,7 @@ class TermsAndConditions extends Component {
     this.setState({ showPrivacy });
   };
 
-  renderTerms = ({ i_header, i_terms }) => {
+  renderTermsSection = ({ i_header, i_terms }) => {
     return (
       <div>
         <h4>{ i_header }</h4>
@@ -53,14 +53,13 @@ class TermsAndConditions extends Component {
         closeOnDimmerClick={ false }
         closeOnEscape={ false }>
         <Modal.Header> 
-          {/* className={ classes.modalHeader } */}
           Terms and Conditions
         </Modal.Header>
         <Modal.Content scrolling>
           {
             !this.state.showPrivacy ?
-              this.renderTerms(snippets.termsOfUse) :
-              this.renderTerms(snippets.privacyAndCookies)
+              this.renderTermsSection(snippets.termsOfUse) :
+              this.renderTermsSection(snippets.privacyAndCookies)
           } 
         </Modal.Content>
         <Modal.Actions>

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -62,8 +62,6 @@ class VisitPage extends Component {
       oldHousing:            clientData.current.housing,
       userChanged:           {},
       snippets:              props.snippets,
-      
-      termsAccepted: false,
     };  // end this.state {}
 
     this.steps = [
@@ -274,23 +272,15 @@ class VisitPage extends Component {
     );
   };  // End getCurrentStep()
 
-  /** Toggles termsAccepted flag in app state.  Passed to TermsAndConditions modal
-   * which calls this in the onClose handler.  App is unavailable until terms 
-   * are accepted.
-   * @method
-   * @param {boolean} termsAccepted
-   */
-  toggleAcceptTerms = (termsAccepted) => {
-    this.setState({ termsAccepted });
-  };  // End acceptTerms()
-
   render() {
+
+    console.log(this.props);
 
     var snippets      = this.state.snippets,
         prevContent   = null,
         nextContent   = null,
         stepIndex     = this.getCurrentStepIndex(),
-        termsAccepted = this.state.termsAccepted;
+        termsAccepted = this.props.termsAccepted;
 
     if (stepIndex !== 0) {
       prevContent = (
@@ -391,7 +381,7 @@ class VisitPage extends Component {
           termsAccepted === false ? 
             <TermsAndConditions
               termsAccepted = { termsAccepted }
-              toggleAcceptTerms = { this.toggleAcceptTerms }
+              toggleAcceptTerms = { this.props.funcs.toggleAcceptTerms }
               snippets={{ ...snippets.termsOfUse }} /> :
             null
         }

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -31,8 +31,6 @@ import { CurrentBenefitsStep } from '../forms/CurrentBenefits';
 import StepBar from '../components/StepBar';
 import { BigButton } from '../forms/inputs';
 import { ButtonReset } from '../forms/ButtonReset';
-
-import { renderIfTrue } from '../components/renderIfTrue';
 import TermsAndConditions from '../components/prompts/TermsAndConditions';
 
 class VisitPage extends Component {
@@ -389,12 +387,14 @@ class VisitPage extends Component {
 
         </Container>
 
-        { renderIfTrue(termsAccepted === false, (
-          <TermsAndConditions
-            termsAccepted = { termsAccepted }
-            toggleAcceptTerms = { this.toggleAcceptTerms }
-            snippets={{ ...snippets.termsOfUse }} />
-        ))}
+        { 
+          termsAccepted === false ? 
+            <TermsAndConditions
+              termsAccepted = { termsAccepted }
+              toggleAcceptTerms = { this.toggleAcceptTerms }
+              snippets={{ ...snippets.termsOfUse }} /> :
+            null
+        }
 
       </div>
     );

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -274,8 +274,6 @@ class VisitPage extends Component {
 
   render() {
 
-    console.log(this.props);
-
     var snippets      = this.state.snippets,
         prevContent   = null,
         nextContent   = null,

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -393,7 +393,7 @@ class VisitPage extends Component {
           <TermsAndConditions
             termsAccepted = { termsAccepted }
             toggleAcceptTerms = { this.toggleAcceptTerms }
-            snippets={{ ...snippets.policies }} />
+            snippets={{ ...snippets.termsOfUse }} />
         ))}
 
       </div>

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -32,6 +32,9 @@ import StepBar from '../components/StepBar';
 import { BigButton } from '../forms/inputs';
 import { ButtonReset } from '../forms/ButtonReset';
 
+import { renderIfTrue } from '../components/renderIfTrue';
+import TermsAndConditions from '../components/prompts/TermsAndConditions';
+
 class VisitPage extends Component {
   constructor (props) {
     super(props);
@@ -61,6 +64,8 @@ class VisitPage extends Component {
       oldHousing:            clientData.current.housing,
       userChanged:           {},
       snippets:              props.snippets,
+      
+      termsAccepted: false,
     };  // end this.state {}
 
     this.steps = [
@@ -271,12 +276,23 @@ class VisitPage extends Component {
     );
   };  // End getCurrentStep()
 
+  /** Toggles termsAccepted flag in app state.  Passed to TermsAndConditions modal
+   * which calls this in the onClose handler.  App is unavailable until terms 
+   * are accepted.
+   * @method
+   * @param {boolean} termsAccepted
+   */
+  toggleAcceptTerms = (termsAccepted) => {
+    this.setState({ termsAccepted });
+  };  // End acceptTerms()
+
   render() {
 
-    var snippets    = this.state.snippets,
-        prevContent = null,
-        nextContent = null,
-        stepIndex   = this.getCurrentStepIndex();
+    var snippets      = this.state.snippets,
+        prevContent   = null,
+        nextContent   = null,
+        stepIndex     = this.getCurrentStepIndex(),
+        termsAccepted = this.state.termsAccepted;
 
     if (stepIndex !== 0) {
       prevContent = (
@@ -372,6 +388,14 @@ class VisitPage extends Component {
           </div>
 
         </Container>
+
+        { renderIfTrue(termsAccepted === false, (
+          <TermsAndConditions
+            termsAccepted = { termsAccepted }
+            toggleAcceptTerms = { this.toggleAcceptTerms }
+            snippets={{ ...snippets.policies }} />
+        ))}
+
       </div>
     );
   }

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -31,7 +31,7 @@ import { CurrentBenefitsStep } from '../forms/CurrentBenefits';
 import StepBar from '../components/StepBar';
 import { BigButton } from '../forms/inputs';
 import { ButtonReset } from '../forms/ButtonReset';
-import TermsAndConditions from '../components/prompts/TermsAndConditions';
+import PredictionsWarning from '../components/prompts/PredictionsWarning';
 
 class VisitPage extends Component {
   constructor (props) {
@@ -377,10 +377,10 @@ class VisitPage extends Component {
 
         { 
           termsAccepted === false ? 
-            <TermsAndConditions
+            <PredictionsWarning
               termsAccepted = { termsAccepted }
               toggleAcceptTerms = { this.props.funcs.toggleAcceptTerms }
-              snippets={{ ...snippets.termsOfUse }} /> :
+              snippets={{ ...snippets.predictions.warningModal }} /> :
             null
         }
 

--- a/src/containers/VisitPage.js
+++ b/src/containers/VisitPage.js
@@ -380,7 +380,7 @@ class VisitPage extends Component {
             <PredictionsWarning
               termsAccepted = { termsAccepted }
               toggleAcceptTerms = { this.props.funcs.toggleAcceptTerms }
-              snippets={{ ...snippets.predictions.warningModal }} /> :
+              snippets={{ ...snippets.warningModal }} /> :
             null
         }
 

--- a/src/index.css
+++ b/src/index.css
@@ -478,3 +478,14 @@ ACCESSIBILITY
   outline: 2px solid rgba(0, 121, 116, 1);
   outline-offset: 1px;
 }
+
+
+/*
+==========================
+TERMS AND CONDITIONS MODAL
+==========================
+*/
+#WarningModal .header {
+  color: #fff;
+  background-color: #db2828;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -487,5 +487,5 @@ TERMS AND CONDITIONS MODAL
 */
 #WarningModal .header {
   color: #fff;
-  background-color: #db2828;
+  background-color: #f2711c;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -487,5 +487,5 @@ PREDICTIONS WARNING MODAL
 */
 #WarningModal .header {
   color: #fff;
-  background-color: #f2711c;
+  background-color: rgb(136,0,21);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -481,9 +481,9 @@ ACCESSIBILITY
 
 
 /*
-==========================
-TERMS AND CONDITIONS MODAL
-==========================
+=========================
+PREDICTIONS WARNING MODAL
+=========================
 */
 #WarningModal .header {
   color: #fff;

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -301,12 +301,13 @@ export default {
       buttonYearly_v1:            `Yearly`, // see cashflow.js, GraphTimeButtons
     },
 
-    policies: {
-      termsOfUse: {
-        header: `IMPORTANT:`,
-        terms:  [ `This tool is in testing.  Predictions should not be used to make financial decisions.` ],
-      },
+    termsOfUse: {
+      header:            `IMPORTANT`,
+      terms:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
       buttonAcceptTerms: `Accept and Continue`,
+      formHeader:        `Please choose one:`,
+      fieldYesLabel:     `I can count on what this tool tells me`,
+      fieldNoLabel:      `I understand that I can't count on what this tool tells me`,
     },
 
   },

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -299,17 +299,17 @@ export default {
       buttonWeekly_v1:            `Weekly`, // see cashflow.js, GraphTimeButtons
       buttonMonthly_v1:           `Monthly`, // see cashflow.js, GraphTimeButtons
       buttonYearly_v1:            `Yearly`, // see cashflow.js, GraphTimeButtons
-
-      warningModal: {
-        header_v1:              `IMPORTANT!`,
-        warning_v1:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
-        buttonAcceptWarning_v1: `Continue`,
-        buttonCancel_v1:        `Cancel`,
-        formInstructions_v1:    `Please choose one:`,
-        radioYesLabel_v1:       `I can count on what this tool tells me`,
-        radioNoLabel_v1:        `I understand that I can't count on what this tool tells me`,
-      },
-
     },
+
+    warningModal: {
+      header_v1:              `IMPORTANT!`,
+      warning_v1:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
+      buttonAcceptWarning_v1: `Continue`,
+      buttonCancel_v1:        `Cancel`,
+      formInstructions_v1:    `Please indicate you understand the following:`,
+      checkboxLabel1:         `This tool is not finished.`,
+      checkboxLabel2:         `I can't count on what this tool tells me.`,
+    },
+
   },
 };

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -27,6 +27,11 @@ export default {
     toAboutPage_v1:      `Learn More`,
   },
 
+  policies: {
+    termsOfUse:        `This is a prototype and should not be used to make financial decisions.`,
+    privacyAndCookies: `Please note that this app does not store user data.`,
+  },
+
   aboutPage: {
     aboutPageHeader_v1: `About the Cliff Effects Tool`,
 

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -299,17 +299,17 @@ export default {
       buttonWeekly_v1:            `Weekly`, // see cashflow.js, GraphTimeButtons
       buttonMonthly_v1:           `Monthly`, // see cashflow.js, GraphTimeButtons
       buttonYearly_v1:            `Yearly`, // see cashflow.js, GraphTimeButtons
-    },
 
-    termsOfUse: {
-      header_v1:             `IMPORTANT!`,
-      terms_v1:              `This tool is in testing.  Predictions should not be used to make financial decisions.`,
-      buttonAcceptTerms_v1:  `Continue`,
-      buttonCancelAccept_v1: `Cancel`,
-      formHeader_v1:         `Please choose one:`,
-      fieldYesLabel_v1:      `I can count on what this tool tells me`,
-      fieldNoLabel_v1:       `I understand that I can't count on what this tool tells me`,
-    },
+      warningModal: {
+        header_v1:              `IMPORTANT!`,
+        warning_v1:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
+        buttonAcceptWarning_v1: `Continue`,
+        buttonCancel_v1:        `Cancel`,
+        formInstructions_v1:    `Please choose one:`,
+        radioYesLabel_v1:       `I can count on what this tool tells me`,
+        radioNoLabel_v1:        `I understand that I can't count on what this tool tells me`,
+      },
 
+    },
   },
 };

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -302,12 +302,13 @@ export default {
     },
 
     termsOfUse: {
-      header:            `IMPORTANT`,
-      terms:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
-      buttonAcceptTerms: `Continue`,
-      formHeader:        `Please choose one:`,
-      fieldYesLabel:     `I can count on what this tool tells me`,
-      fieldNoLabel:      `I understand that I can't count on what this tool tells me`,
+      header:             `IMPORTANT`,
+      terms:              `This tool is in testing.  Predictions should not be used to make financial decisions.`,
+      buttonAcceptTerms:  `Continue`,
+      buttonCancelAccept: `Cancel`,
+      formHeader:         `Please choose one:`,
+      fieldYesLabel:      `I can count on what this tool tells me`,
+      fieldNoLabel:       `I understand that I can't count on what this tool tells me`,
     },
 
   },

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -28,8 +28,23 @@ export default {
   },
 
   policies: {
-    termsOfUse:        `This is a prototype and should not be used to make financial decisions.`,
-    privacyAndCookies: `Please note that this app does not store user data.`,
+    termsOfUse: {
+      header: `Acceptance of Terms`,
+      terms:  [
+        `Use of this site requires your acceptance of these terms and conditions, as well as the site privacy policy.`,
+        `You acknowledge this tool is in testing and the resulting data may be incorrect. Therefore, the information is for educational purposes only and should not be used to make financial decisions.`,
+      ],
+    },
+    privacyAndCookies: {
+      header: `Privacy Policy`,
+      terms:  [
+        `Please note that this app does not store user financial data.`,
+        `However, if you choose to provide feedback through the provided form, you accept that this information will be stored using a third-party service to help us improve site functionality.`,
+      ],
+    },
+    buttonAcceptTerms: `Accept Terms`,
+    buttonBackToTerms: `Back to Terms`,
+    buttonViewPrivacy: `View Privacy Policy`,
   },
 
   aboutPage: {

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -302,7 +302,7 @@ export default {
     },
 
     termsOfUse: {
-      header_v1:             `IMPORTANT`,
+      header_v1:             `IMPORTANT!`,
       terms_v1:              `This tool is in testing.  Predictions should not be used to make financial decisions.`,
       buttonAcceptTerms_v1:  `Continue`,
       buttonCancelAccept_v1: `Cancel`,

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -304,7 +304,7 @@ export default {
     termsOfUse: {
       header:            `IMPORTANT`,
       terms:             `This tool is in testing.  Predictions should not be used to make financial decisions.`,
-      buttonAcceptTerms: `Accept and Continue`,
+      buttonAcceptTerms: `Continue`,
       formHeader:        `Please choose one:`,
       fieldYesLabel:     `I can count on what this tool tells me`,
       fieldNoLabel:      `I understand that I can't count on what this tool tells me`,

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -302,13 +302,13 @@ export default {
     },
 
     termsOfUse: {
-      header:             `IMPORTANT`,
-      terms:              `This tool is in testing.  Predictions should not be used to make financial decisions.`,
-      buttonAcceptTerms:  `Continue`,
-      buttonCancelAccept: `Cancel`,
-      formHeader:         `Please choose one:`,
-      fieldYesLabel:      `I can count on what this tool tells me`,
-      fieldNoLabel:       `I understand that I can't count on what this tool tells me`,
+      header_v1:             `IMPORTANT`,
+      terms_v1:              `This tool is in testing.  Predictions should not be used to make financial decisions.`,
+      buttonAcceptTerms_v1:  `Continue`,
+      buttonCancelAccept_v1: `Cancel`,
+      formHeader_v1:         `Please choose one:`,
+      fieldYesLabel_v1:      `I can count on what this tool tells me`,
+      fieldNoLabel_v1:       `I understand that I can't count on what this tool tells me`,
     },
 
   },

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -27,26 +27,6 @@ export default {
     toAboutPage_v1:      `Learn More`,
   },
 
-  policies: {
-    termsOfUse: {
-      header: `Acceptance of Terms`,
-      terms:  [
-        `Use of this site requires your acceptance of these terms and conditions, as well as the site privacy policy.`,
-        `You acknowledge this tool is in testing and the resulting data may be incorrect. Therefore, the information is for educational purposes only and should not be used to make financial decisions.`,
-      ],
-    },
-    privacyAndCookies: {
-      header: `Privacy Policy`,
-      terms:  [
-        `Please note that this app does not store user financial data.`,
-        `However, if you choose to provide feedback through the provided form, you accept that this information will be stored using a third-party service to help us improve site functionality.`,
-      ],
-    },
-    buttonAcceptTerms: `Accept Terms`,
-    buttonBackToTerms: `Back to Terms`,
-    buttonViewPrivacy: `View Privacy Policy`,
-  },
-
   aboutPage: {
     aboutPageHeader_v1: `About the Cliff Effects Tool`,
 
@@ -320,5 +300,14 @@ export default {
       buttonMonthly_v1:           `Monthly`, // see cashflow.js, GraphTimeButtons
       buttonYearly_v1:            `Yearly`, // see cashflow.js, GraphTimeButtons
     },
+
+    policies: {
+      termsOfUse: {
+        header: `IMPORTANT:`,
+        terms:  [ `This tool is in testing.  Predictions should not be used to make financial decisions.` ],
+      },
+      buttonAcceptTerms: `Accept and Continue`,
+    },
+
   },
 };


### PR DESCRIPTION
This is addressing #761.  I've added items to the EN localization.  Those would need to get added to the google docs as well.  But looking for feedback on general functionality.  

Also, could we get a lawyer to look at the text here?  I took a stab at creating something simple but terms and conditions and privacy policy really should be vetted properly by a lawyer.  

As for privacy policy, we currently don't use cookies do we?  I was thinking of saving a cookie once they accepted the terms so this doesn't display every time.  But then I checked sites like breweries that have age-specific requirements and they ask every time.  If we were to save a cookie, we'd want to add that to the privacy policy.