### PR TITLE
Fixes #914, `onClick` not getting passed to `BigButton`

### DIFF
--- a/src/forms/inputs.js
+++ b/src/forms/inputs.js
@@ -31,11 +31,14 @@ const BigButton = function ({ children, className, overrides, ...otherProps }) {
   }
 
   const overriddenDefaults = {
+    // First adds any random prop
     ...otherProps,
+    // then overrides BigButton-specific props
     type:      `button`,
     color:     `teal`,
     size:      `large`,
     className: allClasses,
+    // then overrides those with props given just for that
     ...overrides,
   };
 

--- a/src/forms/inputs.js
+++ b/src/forms/inputs.js
@@ -19,7 +19,7 @@ import {
 *
 * @returns {object} React element
 */
-const BigButton = function ({ children, className, overrides }) {
+const BigButton = function ({ children, className, overrides, ...otherProps }) {
 
   if (!overrides) {
     overrides = {};
@@ -31,6 +31,7 @@ const BigButton = function ({ children, className, overrides }) {
   }
 
   const overriddenDefaults = {
+    ...otherProps,
     type:      `button`,
     color:     `teal`,
     size:      `large`,

--- a/src/test/forms/inputs/BigButton.test.js
+++ b/src/test/forms/inputs/BigButton.test.js
@@ -6,9 +6,22 @@ import { BigButton } from '../../../forms/inputs';
 describe('<BigButton>', () => {
   it('renders Button with overridden props', () => {
     const child = <span>Click me!</span>;
-    const button = mount(<BigButton className={`test`} overrides={{ color:"red" }}>{child}</BigButton>).find('Button');
+    const button = mount(<BigButton
+      className={ `test` }
+      overrides={{ color: 'red' }}>{child}
+                         </BigButton>).find('Button');
     expect(button.prop('size')).toEqual('large');
     expect(button.prop('color')).toEqual('red');
     expect(button.prop('className')).toEqual('big-button test');
+  });
+
+  it(`renders BigButton with any given props`, () => {
+    const child = <span>Click me!</span>;
+    const button = mount(
+      <BigButton alt={ `test` }>
+        {child}
+      </BigButton>
+    ).find('Button');
+    expect(button.prop(`alt`)).toEqual(`test`);
   });
 });


### PR DESCRIPTION
Also, brings back passing down all props, though keeps `overrides`
because of the order in which we're doing things - first add
the generic props, then add our component specific props,
then override anything that needs it.