### PR TITLE
Change import path of <ExternalLink> Fixes #701

### DIFF
--- a/src/components/AboutContent.js
+++ b/src/components/AboutContent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Header, Message } from 'semantic-ui-react';
-import { ExternalLink } from '../forms/formHelpers';
+import { ExternalLink } from './ExternalLink';
 
 // CUSTOM COMPONENTS
 

--- a/src/forms/formHelpers.js
+++ b/src/forms/formHelpers.js
@@ -10,11 +10,6 @@ import {
   Icon,
 } from 'semantic-ui-react';
 
-// PROJECT COMPONENTS
-// @todo Move all references to this component to the actual component file
-import { ExternalLink } from './../components/ExternalLink';
-
-
 // ========================================
 // INPUT CONTAINER COMPONENTS
 // ========================================
@@ -61,7 +56,6 @@ var AttentionArrow = function () {
 
 
 export {
-  ExternalLink,
   InvalidMessage,
   AttentionArrow,
 };

--- a/src/localization/inlineComponents.js
+++ b/src/localization/inlineComponents.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Icon } from 'semantic-ui-react';
-import { ExternalLink } from '../forms/formHelpers';
+import { ExternalLink } from './../components/ExternalLink';
 import contributors from './contributors';
 
 /** @name inlineComponents


### PR DESCRIPTION
ExternalLink imports moved from formHelper export to src/components