### PR TITLE
Change localization data to object clone instead of object reference

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,10 +88,6 @@ class App extends Component {
       },
       distrustConfirmed: false,
     };
-
-
-
-    console.log(getTextForLanguage(`zh`));
   };  // End constructor()
 
   /**

--- a/src/App.js
+++ b/src/App.js
@@ -88,6 +88,10 @@ class App extends Component {
       },
       distrustConfirmed: false,
     };
+
+
+
+    console.log(getTextForLanguage(`zh`));
   };  // End constructor()
 
   /**

--- a/src/components/dev/DevHud.js
+++ b/src/components/dev/DevHud.js
@@ -12,17 +12,16 @@ import { HeadingWithDetail } from '../details';
 import { CustomClient } from '../CustomClient';
 
 // DATA
-import { localizations } from '../../localization/all';
+import { getLocalizationData } from '../../localization/all';
 
 import { LocalizationReport } from './LocalizationReport.js';
-
 
 /** Contains all HUD items except 'hide' button
  * @todo If there are enough dev features for it,
  *    make menu categories collapsible. */
 const DevMenu = function ({ devProps, funcs, data, state }) {
 
-  var langs    = localizations,
+  var langs    = getLocalizationData(), // Get copy of localization data
       langOpts = [];
 
   for (let key in langs) {

--- a/src/components/dev/LocalizationReport.js
+++ b/src/components/dev/LocalizationReport.js
@@ -9,15 +9,14 @@ import {
 } from 'semantic-ui-react';
 import _ from 'lodash';
 import { getKeyPathsArray, getKeyPathStrings } from '../../utils/objectKeyPaths';
+import { getLocalizationData } from '../../localization/all';
 
-// DATA
-import { localizations } from '../../localization/all';
-
+// Get copy of localization data
+const localizations = getLocalizationData();
 
 const ReportItem = function ({ keyPath, test, locKey, pass }) {
   return (
-    <List.Item
-      key={ keyPath }>
+    <List.Item>
       <List.Icon
         name={ pass ? 'check square' : 'window close' }
         size='large'
@@ -48,7 +47,11 @@ const ReportList = function ({ results }) {
     <List>
       { 
         results.map((filteredResult) => {
-          return <ReportListItems { ...filteredResult } />;
+          return (
+            <ReportListItems
+              key={ filteredResult.keyPath }
+              { ...filteredResult } />
+          );
         })
       }
     </List>

--- a/src/localization/all.js
+++ b/src/localization/all.js
@@ -1,14 +1,27 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import DE from './de';
 import EN from './en';
 import VI from './vi';
 import ZH from './zh';
 
-/** Contains and exports all the language snippet objects */
-var localizations = {
-  de: DE,
-  en: EN,
-  vi: VI,
-  zh: ZH,
+/** 
+ * @returns {function}
+ * 
+ * @summary Exports a function which returns a deep clone of the language snippet objects.
+ * 
+ * @description 
+ * getTextForLanguage() mutates it's localization object, whereas Localization Report in DevHud
+ * compares the raw objects contained in localization files.  By providing a function which returns 
+ * cloned data instead of a reference to the imported objects, the two can coexist.
+*/
+const getLocalizationData = () => {
+  return cloneDeep({
+    de: DE,
+    en: EN,
+    vi: VI,
+    zh: ZH,
+  });
 };
 
-export { localizations };
+export { getLocalizationData };

--- a/src/localization/all.js
+++ b/src/localization/all.js
@@ -11,7 +11,7 @@ import ZH from './zh';
  * @summary Exports a function which returns a deep clone of the language snippet objects.
  * 
  * @description 
- * getTextForLanguage() mutates it's localization object, whereas Localization Report in DevHud
+ * interpolateSnippets() mutates it's localization object, whereas Localization Report in DevHud
  * compares the raw objects contained in localization files.  By providing a function which returns 
  * cloned data instead of a reference to the imported objects, the two can coexist.
 */

--- a/src/utils/getTextForLanguage.js
+++ b/src/utils/getTextForLanguage.js
@@ -5,8 +5,11 @@ import { mergeWith } from 'lodash';
 import { interpolateSnippets } from './interpolation.js';
 
 // DATA
-import { localizations } from '../localization/all';
+import { getLocalizationData } from '../localization/all';
 import inlineComponents from '../localization/inlineComponents';
+
+// Get copy of localization data
+const localizations = getLocalizationData();
 
 // store interpolated and (if necessary) merged snippets objects
 let finishedSnippets = { en: interpolateSnippets(localizations.en, inlineComponents) };


### PR DESCRIPTION
Fixes #947 .  Also moves List.Item key to ReportListItems to fix duplicate keys warning.