### PR TITLE
Change default to display failing checks

### DIFF
--- a/src/components/dev/LocalizationReport.js
+++ b/src/components/dev/LocalizationReport.js
@@ -65,7 +65,7 @@ class LocalizationReport extends Component {
     modalOpen:        false,
     modelLocKey:      null,
     compareLocKey:    null,
-    filter:           'all',
+    filter:           'false',
     localizationKeys: [],
   };
 


### PR DESCRIPTION
Localization Report in DevHud defaulted to showing passing and failing checks.  Request was to change default filter to failing checks.