### PR TITLE
Removes `!important` from index.css wherever possible.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,7 @@ Used to fill vertical space.
 `height: 100%` doesn't work with Flexbox on Mobile Safari.
 */
 .flex-column {
-  display: flex!important;
+  display: flex;
   flex-direction: column;
 }
 .flex-item {
@@ -122,7 +122,7 @@ Used to fill vertical space.
 
 .ui.form h4.ui.header.cashflow-column,
 .ui.form .cashflow .cashflow-column {
-  margin-right: .2em !important;
+  margin-right: .2em;
   width: 7em;
   text-align: center;
 }
@@ -547,8 +547,8 @@ i.icon.details-icon {
 /* HomePage.js styles */
 
 #HomePage {
-  background-image: url(./images/splash.svg) !important;
-  background-size: cover !important;
+  background-image: url(./images/splash.svg);
+  background-size: cover;
   flex: 1 0;
   display: flex;
   flex-direction: column;
@@ -706,7 +706,7 @@ PRINTING STYLES
   }
 
   #App .footer_segment {
-    background: transparent !important;
+    background: transparent;
   }
 
   #App .footer_segment a,
@@ -723,7 +723,7 @@ SMALL SCREEN
 */
 @media only screen and (max-width: 767px) {
   #alwaysLeftButtons {
-    /* Fighting semantic-ui */
+    /* Fighting semantic-ui that use `!important` at this width */
     margin-right: 0!important;
     margin-left: 0!important;
   }


### PR DESCRIPTION
Only two uses remaining and those are fighting semantic-react-ui's own use of `!important`. Don't know why the heck that's in their library at all :P